### PR TITLE
Add dataset management with versioning and parallel uploads

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -17,13 +17,14 @@
   },
   "dependencies": {
     "@lighthouse-tooling/sdk-wrapper": "workspace:*",
-    "@lighthouse-tooling/types": "workspace:*",
     "@lighthouse-tooling/shared": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.0.4"
+    "@lighthouse-tooling/types": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "eventemitter3": "^5.0.1"
   },
   "devDependencies": {
-    "vitest": "^1.0.0",
     "@vitest/coverage-v8": "^1.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/apps/mcp-server/src/handlers/ListResourcesHandler.ts
+++ b/apps/mcp-server/src/handlers/ListResourcesHandler.ts
@@ -6,16 +6,16 @@ import { Logger } from "@lighthouse-tooling/shared";
 import { MCPResponse } from "@lighthouse-tooling/types";
 import { ResponseBuilder } from "../utils/response-builder.js";
 import { ILighthouseService } from "../services/ILighthouseService.js";
-import { MockDatasetService } from "../services/MockDatasetService.js";
+import { IDatasetService } from "../services/IDatasetService.js";
 
 export class ListResourcesHandler {
   private lighthouseService: ILighthouseService;
-  private datasetService: MockDatasetService;
+  private datasetService: IDatasetService;
   private logger: Logger;
 
   constructor(
     lighthouseService: ILighthouseService,
-    datasetService: MockDatasetService,
+    datasetService: IDatasetService,
     logger?: Logger,
   ) {
     this.lighthouseService = lighthouseService;
@@ -36,7 +36,7 @@ export class ListResourcesHandler {
       const files = Array.isArray(filesResult) ? filesResult : await filesResult;
 
       // Get all datasets
-      const datasets = this.datasetService.listDatasets();
+      const datasets = await this.datasetService.listDatasets();
 
       // Format as resources
       const resources = [

--- a/apps/mcp-server/src/services/BatchUploadManager.ts
+++ b/apps/mcp-server/src/services/BatchUploadManager.ts
@@ -1,0 +1,414 @@
+/**
+ * Batch Upload Manager
+ * Handles parallel file uploads with concurrency control, progress tracking,
+ * and partial success handling
+ */
+
+import { EventEmitter } from "eventemitter3";
+import {
+  BatchUploadResult,
+  UploadResult,
+  FailedUpload,
+  AccessCondition,
+} from "@lighthouse-tooling/types";
+import { Logger, AsyncUtils } from "@lighthouse-tooling/shared";
+import { ILighthouseService } from "./ILighthouseService.js";
+import { BatchUploadOptions, DatasetProgress } from "./IDatasetService.js";
+
+/**
+ * Manages batch upload operations with concurrency control and progress tracking
+ */
+export class BatchUploadManager extends EventEmitter {
+  private logger: Logger;
+  private lighthouseService: ILighthouseService;
+
+  // Constants for performance and safety
+  private readonly DEFAULT_CONCURRENCY = 5;
+  private readonly MAX_CONCURRENCY = 20;
+  private readonly DEFAULT_TIMEOUT = 30000; // 30 seconds per file
+  private readonly MEMORY_CHECK_INTERVAL = 100; // Check memory every 100 files
+
+  constructor(lighthouseService: ILighthouseService, logger?: Logger) {
+    super();
+    this.lighthouseService = lighthouseService;
+    this.logger = logger || Logger.getInstance({ level: "info", component: "BatchUploadManager" });
+    this.logger.info("Batch Upload Manager initialized");
+  }
+
+  /**
+   * Upload multiple files in parallel with progress tracking
+   */
+  async uploadFiles(
+    files: string[],
+    uploadConfig: {
+      encrypt?: boolean;
+      accessConditions?: AccessCondition[];
+      tags?: string[];
+    },
+    options: BatchUploadOptions = {},
+  ): Promise<BatchUploadResult> {
+    const startTime = Date.now();
+
+    try {
+      this.logger.info("Starting batch upload", {
+        fileCount: files.length,
+        concurrency: options.concurrency || this.DEFAULT_CONCURRENCY,
+      });
+
+      // Validate and prepare options
+      const concurrency = Math.min(
+        options.concurrency || this.DEFAULT_CONCURRENCY,
+        this.MAX_CONCURRENCY,
+      );
+      const timeout = options.timeout || this.DEFAULT_TIMEOUT;
+      const continueOnError = true; // Always continue on individual file failures
+
+      // Initialize progress tracking
+      const progress: DatasetProgress = {
+        operation: "upload",
+        total: files.length,
+        completed: 0,
+        failed: 0,
+        percentage: 0,
+        timestamp: new Date(),
+      };
+
+      // Arrays to collect results
+      const successfulUploads: UploadResult[] = [];
+      const failedUploads: FailedUpload[] = [];
+
+      // Process files with concurrency control
+      await this.processFilesWithConcurrency(
+        files,
+        uploadConfig,
+        {
+          concurrency,
+          timeout,
+          continueOnError,
+        },
+        progress,
+        successfulUploads,
+        failedUploads,
+        options.onProgress,
+      );
+
+      // Calculate final stats
+      const duration = Date.now() - startTime;
+      const totalBytes = successfulUploads.reduce((sum, upload) => sum + upload.size, 0);
+      const averageSpeed = duration > 0 ? (totalBytes / duration) * 1000 : 0;
+
+      const result: BatchUploadResult = {
+        total: files.length,
+        successful: successfulUploads.length,
+        failed: failedUploads.length,
+        successfulUploads,
+        failedUploads,
+        duration,
+        averageSpeed,
+      };
+
+      this.logger.info("Batch upload completed", {
+        total: result.total,
+        successful: result.successful,
+        failed: result.failed,
+        duration,
+        averageSpeedMBps: (averageSpeed / 1024 / 1024).toFixed(2),
+      });
+
+      return result;
+    } catch (error) {
+      this.logger.error("Batch upload failed", error as Error, {
+        fileCount: files.length,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Process files with concurrency control
+   */
+  private async processFilesWithConcurrency(
+    files: string[],
+    uploadConfig: {
+      encrypt?: boolean;
+      accessConditions?: AccessCondition[];
+      tags?: string[];
+    },
+    options: {
+      concurrency: number;
+      timeout: number;
+      continueOnError: boolean;
+    },
+    progress: DatasetProgress,
+    successfulUploads: UploadResult[],
+    failedUploads: FailedUpload[],
+    onProgress?: (progress: DatasetProgress) => void,
+  ): Promise<void> {
+    // Use AsyncUtils for concurrency control
+    await AsyncUtils.withConcurrency(
+      files,
+      async (filePath, index) => {
+        // Update current file in progress
+        progress.currentFile = filePath;
+        progress.timestamp = new Date();
+
+        try {
+          // Upload file with timeout
+          const result = await this.uploadFileWithTimeout(filePath, uploadConfig, options.timeout);
+
+          // Success - add to successful uploads
+          successfulUploads.push(result);
+          progress.completed++;
+
+          this.logger.debug("File uploaded successfully", {
+            filePath,
+            cid: result.cid,
+            size: result.size,
+            progress: `${progress.completed}/${progress.total}`,
+          });
+        } catch (error) {
+          // Failure - add to failed uploads
+          const failedUpload: FailedUpload = {
+            filePath,
+            error: (error as Error).message,
+            retryAttempts: 0,
+            failedAt: new Date(),
+          };
+
+          failedUploads.push(failedUpload);
+          progress.failed++;
+
+          this.logger.warn("File upload failed", {
+            filePath,
+            error: (error as Error).message,
+            progress: `${progress.completed}/${progress.total}`,
+          });
+
+          // Continue to next file (don't throw)
+        }
+
+        // Update progress percentage and rate
+        progress.percentage = ((progress.completed + progress.failed) / progress.total) * 100;
+        progress.rate = this.calculateRate(progress);
+        progress.estimatedTimeRemaining = this.calculateETA(progress);
+
+        // Emit progress update
+        if (onProgress) {
+          onProgress({ ...progress });
+        }
+
+        this.emit("progress", { ...progress });
+
+        // Memory check periodically
+        if ((index + 1) % this.MEMORY_CHECK_INTERVAL === 0) {
+          this.checkMemoryUsage();
+        }
+
+        // Return void - results are tracked in arrays
+        return;
+      },
+      { maxConcurrent: options.concurrency, timeout: options.timeout },
+    );
+  }
+
+  /**
+   * Upload a single file with timeout
+   */
+  private async uploadFileWithTimeout(
+    filePath: string,
+    uploadConfig: {
+      encrypt?: boolean;
+      accessConditions?: AccessCondition[];
+      tags?: string[];
+    },
+    timeout: number,
+  ): Promise<UploadResult> {
+    return AsyncUtils.withTimeout(
+      this.lighthouseService.uploadFile({
+        filePath,
+        encrypt: uploadConfig.encrypt,
+        accessConditions: uploadConfig.accessConditions,
+        tags: uploadConfig.tags,
+      }),
+      timeout,
+      `Upload timeout for file: ${filePath}`,
+    );
+  }
+
+  /**
+   * Calculate current upload rate (files per second)
+   */
+  private calculateRate(progress: DatasetProgress): number {
+    if (!progress.timestamp) return 0;
+
+    // Simple estimation based on completed files
+    const elapsed = Date.now() - progress.timestamp.getTime();
+    if (elapsed === 0) return 0;
+
+    return (progress.completed / elapsed) * 1000;
+  }
+
+  /**
+   * Calculate estimated time remaining
+   */
+  private calculateETA(progress: DatasetProgress): number | undefined {
+    if (!progress.rate || progress.rate === 0) return undefined;
+
+    const remaining = progress.total - progress.completed - progress.failed;
+    return (remaining / progress.rate) * 1000; // milliseconds
+  }
+
+  /**
+   * Check memory usage and warn if too high
+   */
+  private checkMemoryUsage(): void {
+    const usage = process.memoryUsage();
+    const heapUsedMB = usage.heapUsed / 1024 / 1024;
+    const heapTotalMB = usage.heapTotal / 1024 / 1024;
+
+    // Warn if heap usage exceeds 500MB
+    if (heapUsedMB > 500) {
+      this.logger.warn("High memory usage detected", {
+        heapUsedMB: heapUsedMB.toFixed(2),
+        heapTotalMB: heapTotalMB.toFixed(2),
+        utilizationPercent: ((heapUsedMB / heapTotalMB) * 100).toFixed(2),
+      });
+    }
+
+    // Log memory stats at debug level
+    this.logger.debug("Memory usage", {
+      heapUsedMB: heapUsedMB.toFixed(2),
+      heapTotalMB: heapTotalMB.toFixed(2),
+      rss: (usage.rss / 1024 / 1024).toFixed(2),
+    });
+  }
+
+  /**
+   * Upload files in batches to manage memory
+   * Useful for very large datasets (1000+ files)
+   */
+  async uploadFilesInBatches(
+    files: string[],
+    uploadConfig: {
+      encrypt?: boolean;
+      accessConditions?: AccessCondition[];
+      tags?: string[];
+    },
+    options: BatchUploadOptions & { batchSize?: number } = {},
+  ): Promise<BatchUploadResult> {
+    const batchSize = options.batchSize || 50; // Process 50 files per batch
+    const startTime = Date.now();
+
+    this.logger.info("Starting batched upload", {
+      totalFiles: files.length,
+      batchSize,
+      batches: Math.ceil(files.length / batchSize),
+    });
+
+    const allSuccessful: UploadResult[] = [];
+    const allFailed: FailedUpload[] = [];
+
+    // Process in batches
+    for (let i = 0; i < files.length; i += batchSize) {
+      const batch = files.slice(i, i + batchSize);
+      const batchNumber = Math.floor(i / batchSize) + 1;
+
+      this.logger.info("Processing batch", {
+        batch: batchNumber,
+        files: batch.length,
+        progress: `${Math.min(i + batchSize, files.length)}/${files.length}`,
+      });
+
+      // Upload batch
+      const batchResult = await this.uploadFiles(batch, uploadConfig, {
+        ...options,
+        onProgress: (progress) => {
+          // Adjust progress to account for overall progress
+          const overallProgress: DatasetProgress = {
+            ...progress,
+            total: files.length,
+            completed: allSuccessful.length + progress.completed,
+            failed: allFailed.length + progress.failed,
+            percentage: ((allSuccessful.length + progress.completed) / files.length) * 100,
+          };
+
+          if (options.onProgress) {
+            options.onProgress(overallProgress);
+          }
+
+          this.emit("progress", overallProgress);
+        },
+      });
+
+      // Collect results
+      allSuccessful.push(...batchResult.successfulUploads);
+      allFailed.push(...batchResult.failedUploads);
+
+      // Allow GC to clean up batch results
+      batchResult.successfulUploads.length = 0;
+      batchResult.failedUploads.length = 0;
+
+      // Check memory after each batch
+      this.checkMemoryUsage();
+    }
+
+    const duration = Date.now() - startTime;
+    const totalBytes = allSuccessful.reduce((sum, upload) => sum + upload.size, 0);
+    const averageSpeed = duration > 0 ? (totalBytes / duration) * 1000 : 0;
+
+    const result: BatchUploadResult = {
+      total: files.length,
+      successful: allSuccessful.length,
+      failed: allFailed.length,
+      successfulUploads: allSuccessful,
+      failedUploads: allFailed,
+      duration,
+      averageSpeed,
+    };
+
+    this.logger.info("Batched upload completed", {
+      total: result.total,
+      successful: result.successful,
+      failed: result.failed,
+      duration,
+      durationMinutes: (duration / 1000 / 60).toFixed(2),
+      averageSpeedMBps: (averageSpeed / 1024 / 1024).toFixed(2),
+    });
+
+    return result;
+  }
+
+  /**
+   * Get optimal batch configuration based on file count
+   */
+  getOptimalBatchConfig(fileCount: number): {
+    useBatching: boolean;
+    batchSize: number;
+    concurrency: number;
+  } {
+    // For large datasets (1000+), use batching
+    if (fileCount >= 1000) {
+      return {
+        useBatching: true,
+        batchSize: 50,
+        concurrency: 5,
+      };
+    }
+
+    // For medium datasets (100-999), use standard parallel upload
+    if (fileCount >= 100) {
+      return {
+        useBatching: false,
+        batchSize: fileCount,
+        concurrency: 10,
+      };
+    }
+
+    // For small datasets (<100), use default concurrency
+    return {
+      useBatching: false,
+      batchSize: fileCount,
+      concurrency: 5,
+    };
+  }
+}

--- a/apps/mcp-server/src/services/DatasetService.ts
+++ b/apps/mcp-server/src/services/DatasetService.ts
@@ -1,0 +1,665 @@
+/**
+ * Dataset Service
+ * Complete implementation of dataset management with versioning, parallel uploads,
+ * and comprehensive error handling
+ */
+
+import { EventEmitter } from "eventemitter3";
+import {
+  Dataset,
+  DatasetConfig,
+  DatasetUpdate,
+  DatasetFilter,
+  DatasetStats,
+  DatasetVersion,
+  VersionChanges,
+  VersionDiff,
+  BatchUploadResult,
+  UploadResult,
+} from "@lighthouse-tooling/types";
+import { Logger } from "@lighthouse-tooling/shared";
+import { CIDGenerator } from "../utils/cid-generator.js";
+import { ILighthouseService } from "./ILighthouseService.js";
+import {
+  IDatasetService,
+  DatasetCreateOptions,
+  BatchUploadOptions,
+  DatasetServiceStats,
+} from "./IDatasetService.js";
+import { DatasetVersionManager } from "./DatasetVersionManager.js";
+import { BatchUploadManager } from "./BatchUploadManager.js";
+
+/**
+ * Complete dataset service implementation with versioning and parallel processing
+ */
+export class DatasetService extends EventEmitter implements IDatasetService {
+  private datasets: Map<string, Dataset> = new Map();
+  private logger: Logger;
+  private lighthouseService: ILighthouseService;
+  private versionManager: DatasetVersionManager;
+  private uploadManager: BatchUploadManager;
+
+  constructor(lighthouseService: ILighthouseService, logger?: Logger) {
+    super();
+    this.lighthouseService = lighthouseService;
+    this.logger = logger || Logger.getInstance({ level: "info", component: "DatasetService" });
+    this.versionManager = new DatasetVersionManager(this.logger);
+    this.uploadManager = new BatchUploadManager(this.lighthouseService, this.logger);
+
+    // Forward upload progress events
+    this.uploadManager.on("progress", (progress) => {
+      this.emit("dataset:progress", progress);
+    });
+
+    this.logger.info("Dataset Service initialized");
+  }
+
+  /**
+   * Create a new dataset with parallel file uploads
+   */
+  async createDataset(
+    config: DatasetConfig,
+    files: string[],
+    options: DatasetCreateOptions = {},
+  ): Promise<Dataset> {
+    const startTime = Date.now();
+
+    try {
+      this.logger.info("Creating dataset", {
+        name: config.name,
+        fileCount: files.length,
+        concurrency: options.concurrency || 5,
+      });
+
+      // Validate inputs
+      this.validateDatasetConfig(config);
+      this.validateFiles(files);
+
+      // Check for duplicate name
+      if (this.datasetExistsByName(config.name)) {
+        throw new Error(`Dataset with name "${config.name}" already exists`);
+      }
+
+      // Emit start event
+      this.emit("dataset:create:start", { name: config.name, fileCount: files.length });
+
+      // Determine upload strategy based on file count
+      const batchConfig = this.uploadManager.getOptimalBatchConfig(files.length);
+      const uploadOptions: BatchUploadOptions = {
+        concurrency: options.concurrency || batchConfig.concurrency,
+        timeout: options.timeout,
+        maxRetries: options.maxRetries,
+        onProgress: options.onProgress,
+        createVersion: false, // Will create initial version manually
+      };
+
+      // Upload files
+      let batchResult: BatchUploadResult;
+      if (batchConfig.useBatching && files.length >= 1000) {
+        this.logger.info("Using batched upload for large dataset", {
+          fileCount: files.length,
+          batchSize: batchConfig.batchSize,
+        });
+        batchResult = await this.uploadManager.uploadFilesInBatches(
+          files,
+          {
+            encrypt: config.encrypt,
+            accessConditions: config.accessConditions,
+            tags: config.tags,
+          },
+          { ...uploadOptions, batchSize: batchConfig.batchSize },
+        );
+      } else {
+        batchResult = await this.uploadManager.uploadFiles(
+          files,
+          {
+            encrypt: config.encrypt,
+            accessConditions: config.accessConditions,
+            tags: config.tags,
+          },
+          uploadOptions,
+        );
+      }
+
+      // Check if we should continue despite failures
+      if (batchResult.failed > 0) {
+        this.logger.warn("Some files failed to upload", {
+          successful: batchResult.successful,
+          failed: batchResult.failed,
+        });
+
+        if (options.continueOnError === false && batchResult.failed > 0) {
+          throw new Error(
+            `Failed to upload ${batchResult.failed} files. Set continueOnError to true to create dataset with partial uploads.`,
+          );
+        }
+      }
+
+      // Generate dataset ID
+      const datasetId = CIDGenerator.generate(`dataset-${config.name}-${Date.now()}`);
+
+      // Create initial dataset object
+      const dataset: Dataset = {
+        id: datasetId,
+        name: config.name,
+        description: config.description || "",
+        files: batchResult.successfulUploads,
+        metadata: {
+          author: config.metadata?.author,
+          license: config.metadata?.license,
+          category: config.metadata?.category,
+          keywords: config.metadata?.keywords,
+          custom: config.metadata?.custom,
+        },
+        version: "1.0.0",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        encrypted: config.encrypt || false,
+        accessConditions: config.accessConditions,
+      };
+
+      // Store dataset
+      this.datasets.set(datasetId, dataset);
+
+      // Create initial version
+      const initialChanges: VersionChanges = {
+        filesAdded: batchResult.successfulUploads.map((f) => f.cid),
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: `Initial dataset creation with ${batchResult.successful} files`,
+      };
+
+      await this.versionManager.createVersion(dataset, initialChanges, "system");
+
+      const executionTime = Date.now() - startTime;
+
+      this.logger.info("Dataset created successfully", {
+        datasetId,
+        name: config.name,
+        fileCount: batchResult.successful,
+        failedCount: batchResult.failed,
+        executionTime,
+        executionTimeMinutes: (executionTime / 1000 / 60).toFixed(2),
+      });
+
+      // Emit completion event
+      this.emit("dataset:create:complete", {
+        dataset,
+        batchResult,
+        executionTime,
+      });
+
+      return dataset;
+    } catch (error) {
+      this.logger.error("Dataset creation failed", error as Error, {
+        name: config.name,
+        fileCount: files.length,
+      });
+
+      this.emit("dataset:create:error", {
+        name: config.name,
+        error: (error as Error).message,
+      });
+
+      throw error;
+    }
+  }
+
+  /**
+   * Get a dataset by ID, optionally at a specific version
+   */
+  async getDataset(datasetId: string, version?: string): Promise<Dataset> {
+    try {
+      const dataset = this.datasets.get(datasetId);
+      if (!dataset) {
+        throw new Error(`Dataset not found: ${datasetId}`);
+      }
+
+      // If version specified, get from version history
+      if (version) {
+        const versionRecord = this.versionManager.getVersion(datasetId, version);
+        if (!versionRecord) {
+          throw new Error(`Version ${version} not found for dataset ${datasetId}`);
+        }
+
+        // Reconstruct dataset from version snapshot
+        return {
+          ...dataset,
+          files: versionRecord.snapshot.files,
+          metadata: versionRecord.snapshot.metadata,
+          version: versionRecord.version,
+        };
+      }
+
+      return dataset;
+    } catch (error) {
+      this.logger.error("Failed to get dataset", error as Error, { datasetId, version });
+      throw error;
+    }
+  }
+
+  /**
+   * Update an existing dataset
+   */
+  async updateDataset(datasetId: string, updates: DatasetUpdate): Promise<Dataset> {
+    try {
+      const dataset = this.datasets.get(datasetId);
+      if (!dataset) {
+        throw new Error(`Dataset not found: ${datasetId}`);
+      }
+
+      this.logger.info("Updating dataset", { datasetId, updates });
+
+      // Track changes for versioning
+      const changes: VersionChanges = {
+        filesAdded: [],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "",
+      };
+
+      // Apply description update
+      if (updates.description !== undefined) {
+        dataset.description = updates.description;
+        changes.configChanged = true;
+      }
+
+      // Apply metadata updates
+      if (updates.metadata) {
+        dataset.metadata = {
+          ...dataset.metadata,
+          ...updates.metadata,
+          custom: {
+            ...dataset.metadata.custom,
+            ...updates.metadata.custom,
+          },
+        };
+        changes.metadataChanged = true;
+      }
+
+      // Add files if specified
+      if (updates.addFiles && updates.addFiles.length > 0) {
+        const uploadResult = await this.uploadManager.uploadFiles(
+          updates.addFiles,
+          {
+            encrypt: dataset.encrypted,
+            accessConditions: dataset.accessConditions,
+          },
+          { continueOnError: true },
+        );
+
+        dataset.files.push(...uploadResult.successfulUploads);
+        changes.filesAdded = uploadResult.successfulUploads.map((f) => f.cid);
+
+        this.logger.info("Files added to dataset", {
+          datasetId,
+          added: uploadResult.successful,
+          failed: uploadResult.failed,
+        });
+      }
+
+      // Remove files if specified
+      if (updates.removeFiles && updates.removeFiles.length > 0) {
+        const removeSet = new Set(updates.removeFiles);
+        const removedFiles = dataset.files.filter((f) => removeSet.has(f.cid));
+        dataset.files = dataset.files.filter((f) => !removeSet.has(f.cid));
+        changes.filesRemoved = removedFiles.map((f) => f.cid);
+
+        this.logger.info("Files removed from dataset", {
+          datasetId,
+          removed: removedFiles.length,
+        });
+      }
+
+      // Update tags
+      if (updates.addTags || updates.removeTags) {
+        const keywords = new Set(dataset.metadata.keywords || []);
+
+        if (updates.addTags) {
+          updates.addTags.forEach((tag) => keywords.add(tag));
+        }
+
+        if (updates.removeTags) {
+          updates.removeTags.forEach((tag) => keywords.delete(tag));
+        }
+
+        dataset.metadata.keywords = Array.from(keywords);
+        changes.metadataChanged = true;
+      }
+
+      // Update timestamp
+      dataset.updatedAt = new Date();
+
+      // Create summary of changes
+      const changeParts: string[] = [];
+      if (changes.filesAdded.length > 0)
+        changeParts.push(`Added ${changes.filesAdded.length} files`);
+      if (changes.filesRemoved.length > 0)
+        changeParts.push(`Removed ${changes.filesRemoved.length} files`);
+      if (changes.metadataChanged) changeParts.push("Updated metadata");
+      if (changes.configChanged) changeParts.push("Updated configuration");
+
+      changes.summary = changeParts.length > 0 ? changeParts.join(", ") : "No changes";
+
+      // Create new version
+      const newVersion = await this.versionManager.createVersion(dataset, changes, "user");
+      dataset.version = newVersion.version;
+
+      this.logger.info("Dataset updated successfully", {
+        datasetId,
+        newVersion: dataset.version,
+        changes: changes.summary,
+      });
+
+      return dataset;
+    } catch (error) {
+      this.logger.error("Failed to update dataset", error as Error, { datasetId });
+      throw error;
+    }
+  }
+
+  /**
+   * List datasets with filtering
+   */
+  async listDatasets(filter?: DatasetFilter): Promise<Dataset[]> {
+    let datasets = Array.from(this.datasets.values());
+
+    if (filter) {
+      // Filter by encryption
+      if (filter.encrypted !== undefined) {
+        datasets = datasets.filter((d) => d.encrypted === filter.encrypted);
+      }
+
+      // Filter by name pattern
+      if (filter.namePattern) {
+        const pattern = new RegExp(filter.namePattern, "i");
+        datasets = datasets.filter((d) => pattern.test(d.name));
+      }
+
+      // Filter by tags
+      if (filter.tags && filter.tags.length > 0) {
+        datasets = datasets.filter((d) =>
+          filter.tags!.some((tag) => d.metadata.keywords?.includes(tag)),
+        );
+      }
+
+      // Filter by author
+      if (filter.author) {
+        datasets = datasets.filter((d) => d.metadata.author === filter.author);
+      }
+
+      // Filter by category
+      if (filter.category) {
+        datasets = datasets.filter((d) => d.metadata.category === filter.category);
+      }
+
+      // Filter by creation date
+      if (filter.createdAfter) {
+        datasets = datasets.filter((d) => d.createdAt >= filter.createdAfter!);
+      }
+
+      if (filter.createdBefore) {
+        datasets = datasets.filter((d) => d.createdAt <= filter.createdBefore!);
+      }
+
+      // Filter by file count
+      if (filter.minFiles !== undefined) {
+        datasets = datasets.filter((d) => d.files.length >= filter.minFiles!);
+      }
+
+      if (filter.maxFiles !== undefined) {
+        datasets = datasets.filter((d) => d.files.length <= filter.maxFiles!);
+      }
+
+      // Apply pagination
+      const offset = filter.offset || 0;
+      const limit = filter.limit || datasets.length;
+      datasets = datasets.slice(offset, offset + limit);
+    }
+
+    return datasets;
+  }
+
+  /**
+   * Delete a dataset
+   */
+  async deleteDataset(datasetId: string): Promise<boolean> {
+    try {
+      const dataset = this.datasets.get(datasetId);
+      if (!dataset) {
+        return false;
+      }
+
+      // Delete dataset
+      this.datasets.delete(datasetId);
+
+      // Clear version history
+      this.versionManager.clearDatasetVersions(datasetId);
+
+      this.logger.info("Dataset deleted", { datasetId, name: dataset.name });
+
+      return true;
+    } catch (error) {
+      this.logger.error("Failed to delete dataset", error as Error, { datasetId });
+      throw error;
+    }
+  }
+
+  /**
+   * Create a new version
+   */
+  async createVersion(datasetId: string, changes: VersionChanges): Promise<DatasetVersion> {
+    const dataset = this.datasets.get(datasetId);
+    if (!dataset) {
+      throw new Error(`Dataset not found: ${datasetId}`);
+    }
+
+    return this.versionManager.createVersion(dataset, changes);
+  }
+
+  /**
+   * List all versions of a dataset
+   */
+  async listVersions(datasetId: string): Promise<DatasetVersion[]> {
+    return this.versionManager.listVersions(datasetId);
+  }
+
+  /**
+   * Rollback to a previous version
+   */
+  async rollbackToVersion(datasetId: string, version: string): Promise<Dataset> {
+    const dataset = this.datasets.get(datasetId);
+    if (!dataset) {
+      throw new Error(`Dataset not found: ${datasetId}`);
+    }
+
+    const rolledBack = await this.versionManager.rollbackToVersion(dataset, version);
+
+    // Update stored dataset
+    this.datasets.set(datasetId, rolledBack);
+
+    return rolledBack;
+  }
+
+  /**
+   * Compare versions
+   */
+  async compareVersions(
+    datasetId: string,
+    fromVersion: string,
+    toVersion: string,
+  ): Promise<VersionDiff> {
+    return this.versionManager.compareVersions(datasetId, fromVersion, toVersion);
+  }
+
+  /**
+   * Add files to a dataset
+   */
+  async addFilesToDataset(
+    datasetId: string,
+    files: string[],
+    options?: BatchUploadOptions,
+  ): Promise<BatchUploadResult> {
+    const dataset = this.datasets.get(datasetId);
+    if (!dataset) {
+      throw new Error(`Dataset not found: ${datasetId}`);
+    }
+
+    const batchResult = await this.uploadManager.uploadFiles(
+      files,
+      {
+        encrypt: dataset.encrypted,
+        accessConditions: dataset.accessConditions,
+      },
+      options || {},
+    );
+
+    // Add successful uploads to dataset
+    dataset.files.push(...batchResult.successfulUploads);
+    dataset.updatedAt = new Date();
+
+    // Create new version if requested
+    if (options?.createVersion !== false) {
+      const changes: VersionChanges = {
+        filesAdded: batchResult.successfulUploads.map((f) => f.cid),
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: `Added ${batchResult.successful} files`,
+      };
+
+      const newVersion = await this.versionManager.createVersion(dataset, changes);
+      dataset.version = newVersion.version;
+    }
+
+    return batchResult;
+  }
+
+  /**
+   * Remove files from a dataset
+   */
+  async removeFilesFromDataset(datasetId: string, cids: string[]): Promise<Dataset> {
+    const dataset = this.datasets.get(datasetId);
+    if (!dataset) {
+      throw new Error(`Dataset not found: ${datasetId}`);
+    }
+
+    const removeSet = new Set(cids);
+    const removedFiles = dataset.files.filter((f) => removeSet.has(f.cid));
+    dataset.files = dataset.files.filter((f) => !removeSet.has(f.cid));
+    dataset.updatedAt = new Date();
+
+    // Create new version
+    const changes: VersionChanges = {
+      filesAdded: [],
+      filesRemoved: removedFiles.map((f) => f.cid),
+      filesModified: [],
+      metadataChanged: false,
+      configChanged: false,
+      summary: `Removed ${removedFiles.length} files`,
+    };
+
+    const newVersion = await this.versionManager.createVersion(dataset, changes);
+    dataset.version = newVersion.version;
+
+    return dataset;
+  }
+
+  /**
+   * Get dataset statistics
+   */
+  async getDatasetStats(datasetId: string): Promise<DatasetStats> {
+    const dataset = this.datasets.get(datasetId);
+    if (!dataset) {
+      throw new Error(`Dataset not found: ${datasetId}`);
+    }
+
+    const fileSizes = dataset.files.map((f) => f.size);
+    const totalSize = fileSizes.reduce((sum, size) => sum + size, 0);
+    const averageFileSize = fileSizes.length > 0 ? totalSize / fileSizes.length : 0;
+    const largestFileSize = fileSizes.length > 0 ? Math.max(...fileSizes) : 0;
+    const smallestFileSize = fileSizes.length > 0 ? Math.min(...fileSizes) : 0;
+
+    return {
+      id: dataset.id,
+      name: dataset.name,
+      fileCount: dataset.files.length,
+      totalSize,
+      encrypted: dataset.encrypted,
+      version: dataset.version,
+      versionCount: this.versionManager.getVersionCount(datasetId),
+      createdAt: dataset.createdAt,
+      updatedAt: dataset.updatedAt,
+      averageFileSize,
+      largestFileSize,
+      smallestFileSize,
+    };
+  }
+
+  /**
+   * Get overall service statistics
+   */
+  getAllStats(): DatasetServiceStats {
+    const datasets = Array.from(this.datasets.values());
+    const totalFiles = datasets.reduce((sum, d) => sum + d.files.length, 0);
+    const totalSize = datasets.reduce((sum, d) => sum + d.files.reduce((s, f) => s + f.size, 0), 0);
+    const encryptedDatasets = datasets.filter((d) => d.encrypted).length;
+
+    return {
+      totalDatasets: datasets.length,
+      totalFiles,
+      totalSize,
+      encryptedDatasets,
+      totalVersions: this.versionManager.getTotalVersionCount(),
+      averageFilesPerDataset: datasets.length > 0 ? totalFiles / datasets.length : 0,
+      averageDatasetSize: datasets.length > 0 ? totalSize / datasets.length : 0,
+    };
+  }
+
+  /**
+   * Clear all datasets
+   */
+  clear(): void {
+    this.datasets.clear();
+    this.versionManager.clear();
+    this.logger.info("All datasets cleared");
+  }
+
+  /**
+   * Validate dataset configuration
+   */
+  private validateDatasetConfig(config: DatasetConfig): void {
+    if (!config.name || config.name.trim().length === 0) {
+      throw new Error("Dataset name is required");
+    }
+
+    if (config.name.length > 255) {
+      throw new Error("Dataset name must be less than 255 characters");
+    }
+  }
+
+  /**
+   * Validate files array
+   */
+  private validateFiles(files: string[]): void {
+    if (!files || files.length === 0) {
+      throw new Error("At least one file is required");
+    }
+
+    if (files.length > 10000) {
+      throw new Error("Maximum 10,000 files per dataset");
+    }
+  }
+
+  /**
+   * Check if dataset exists by name
+   */
+  private datasetExistsByName(name: string): boolean {
+    return Array.from(this.datasets.values()).some((d) => d.name === name);
+  }
+}

--- a/apps/mcp-server/src/services/DatasetVersionManager.ts
+++ b/apps/mcp-server/src/services/DatasetVersionManager.ts
@@ -1,0 +1,431 @@
+/**
+ * Dataset Version Manager
+ * Handles semantic versioning, version history, and rollback capabilities for datasets
+ */
+
+import {
+  Dataset,
+  DatasetVersion,
+  VersionChanges,
+  DatasetSnapshot,
+  VersionDiff,
+  DatasetMetadata,
+  DatasetConfig,
+  UploadResult,
+} from "@lighthouse-tooling/types";
+import { Logger } from "@lighthouse-tooling/shared";
+import { CIDGenerator } from "../utils/cid-generator.js";
+
+/**
+ * Manages dataset versioning with semantic versioning support
+ */
+export class DatasetVersionManager {
+  private versions: Map<string, DatasetVersion[]> = new Map(); // datasetId -> versions array
+  private logger: Logger;
+
+  constructor(logger?: Logger) {
+    this.logger =
+      logger || Logger.getInstance({ level: "info", component: "DatasetVersionManager" });
+    this.logger.info("Dataset Version Manager initialized");
+  }
+
+  /**
+   * Create a new version for a dataset
+   */
+  async createVersion(
+    dataset: Dataset,
+    changes: VersionChanges,
+    createdBy?: string,
+  ): Promise<DatasetVersion> {
+    try {
+      this.logger.info("Creating new version", {
+        datasetId: dataset.id,
+        currentVersion: dataset.version,
+      });
+
+      // Get existing versions for this dataset
+      const existingVersions = this.versions.get(dataset.id) || [];
+
+      // Parse current version
+      const currentVersion = this.parseVersion(dataset.version);
+
+      // Determine new version based on changes
+      const newVersion = this.bumpVersion(currentVersion, changes);
+      const versionString = this.formatVersion(newVersion);
+
+      // Create snapshot of current dataset state
+      const snapshot = this.createSnapshot(dataset);
+
+      // Create version record
+      const version: DatasetVersion = {
+        id: CIDGenerator.generate(`version-${dataset.id}-${versionString}-${Date.now()}`),
+        datasetId: dataset.id,
+        version: versionString,
+        changes,
+        snapshot,
+        createdAt: new Date(),
+        createdBy,
+        changeDescription: changes.summary,
+        tags: [],
+      };
+
+      // Store version
+      existingVersions.push(version);
+      this.versions.set(dataset.id, existingVersions);
+
+      this.logger.info("Version created successfully", {
+        datasetId: dataset.id,
+        version: versionString,
+        versionId: version.id,
+      });
+
+      return version;
+    } catch (error) {
+      this.logger.error("Failed to create version", error as Error, {
+        datasetId: dataset.id,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get all versions for a dataset
+   */
+  listVersions(datasetId: string): DatasetVersion[] {
+    const versions = this.versions.get(datasetId) || [];
+    // Return sorted by version (newest first)
+    return versions.sort((a, b) => {
+      const versionA = this.parseVersion(a.version);
+      const versionB = this.parseVersion(b.version);
+      return this.compareVersionTuples(versionB, versionA);
+    });
+  }
+
+  /**
+   * Get a specific version
+   */
+  getVersion(datasetId: string, versionString: string): DatasetVersion | undefined {
+    const versions = this.versions.get(datasetId) || [];
+    return versions.find((v) => v.version === versionString);
+  }
+
+  /**
+   * Rollback dataset to a previous version
+   */
+  async rollbackToVersion(dataset: Dataset, targetVersion: string): Promise<Dataset> {
+    try {
+      this.logger.info("Rolling back dataset", {
+        datasetId: dataset.id,
+        fromVersion: dataset.version,
+        toVersion: targetVersion,
+      });
+
+      const version = this.getVersion(dataset.id, targetVersion);
+      if (!version) {
+        throw new Error(`Version ${targetVersion} not found for dataset ${dataset.id}`);
+      }
+
+      // Create changes record for the rollback
+      const changes = this.computeChangesForRollback(dataset, version.snapshot);
+
+      // Create a new version for the rollback action
+      const rollbackVersion = await this.createVersion(dataset, changes, "system");
+
+      // Restore dataset state from snapshot
+      const restoredDataset: Dataset = {
+        ...dataset,
+        files: [...version.snapshot.files],
+        metadata: { ...version.snapshot.metadata },
+        version: rollbackVersion.version,
+        updatedAt: new Date(),
+      };
+
+      this.logger.info("Rollback completed", {
+        datasetId: dataset.id,
+        restoredToVersion: targetVersion,
+        newVersion: rollbackVersion.version,
+      });
+
+      return restoredDataset;
+    } catch (error) {
+      this.logger.error("Rollback failed", error as Error, {
+        datasetId: dataset.id,
+        targetVersion,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Compare two versions and return differences
+   */
+  compareVersions(
+    datasetId: string,
+    fromVersionString: string,
+    toVersionString: string,
+  ): VersionDiff {
+    const fromVersion = this.getVersion(datasetId, fromVersionString);
+    const toVersion = this.getVersion(datasetId, toVersionString);
+
+    if (!fromVersion || !toVersion) {
+      throw new Error(`One or both versions not found: ${fromVersionString}, ${toVersionString}`);
+    }
+
+    const fromFiles = new Map(fromVersion.snapshot.files.map((f) => [f.cid, f]));
+    const toFiles = new Map(toVersion.snapshot.files.map((f) => [f.cid, f]));
+
+    // Find added files
+    const filesAdded: UploadResult[] = [];
+    toFiles.forEach((file, cid) => {
+      if (!fromFiles.has(cid)) {
+        filesAdded.push(file);
+      }
+    });
+
+    // Find removed files
+    const filesRemoved: UploadResult[] = [];
+    fromFiles.forEach((file, cid) => {
+      if (!toFiles.has(cid)) {
+        filesRemoved.push(file);
+      }
+    });
+
+    // Find modified files (same CID but different metadata)
+    const filesModified: UploadResult[] = [];
+    toFiles.forEach((file, cid) => {
+      const oldFile = fromFiles.get(cid);
+      if (oldFile && JSON.stringify(oldFile) !== JSON.stringify(file)) {
+        filesModified.push(file);
+      }
+    });
+
+    // Compare metadata
+    const metadataChanges = this.computeMetadataChanges(
+      fromVersion.snapshot.metadata,
+      toVersion.snapshot.metadata,
+    );
+
+    // Generate summary
+    const summary = this.generateDiffSummary(
+      filesAdded.length,
+      filesRemoved.length,
+      filesModified.length,
+      Object.keys(metadataChanges).length,
+    );
+
+    return {
+      fromVersion: fromVersionString,
+      toVersion: toVersionString,
+      filesAdded,
+      filesRemoved,
+      filesModified,
+      metadataChanges,
+      summary,
+    };
+  }
+
+  /**
+   * Parse semantic version string to tuple
+   */
+  private parseVersion(versionString: string): [number, number, number] {
+    const parts = versionString.split(".");
+    if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
+      throw new Error(`Invalid version format: ${versionString}`);
+    }
+
+    const major = parseInt(parts[0], 10);
+    const minor = parseInt(parts[1], 10);
+    const patch = parseInt(parts[2], 10);
+
+    if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+      throw new Error(`Invalid version numbers: ${versionString}`);
+    }
+
+    return [major, minor, patch];
+  }
+
+  /**
+   * Format version tuple to string
+   */
+  private formatVersion(version: [number, number, number]): string {
+    return `${version[0]}.${version[1]}.${version[2]}`;
+  }
+
+  /**
+   * Bump version based on changes according to semantic versioning
+   */
+  private bumpVersion(
+    current: [number, number, number],
+    changes: VersionChanges,
+  ): [number, number, number] {
+    const [major, minor, patch] = current;
+
+    // Major version bump: Breaking changes (files removed or significant changes)
+    if (changes.filesRemoved.length > 0) {
+      return [major + 1, 0, 0];
+    }
+
+    // Minor version bump: New features (files added)
+    if (changes.filesAdded.length > 0) {
+      return [major, minor + 1, 0];
+    }
+
+    // Patch version bump: Bug fixes, metadata changes, file modifications
+    if (changes.filesModified.length > 0 || changes.metadataChanged || changes.configChanged) {
+      return [major, minor, patch + 1];
+    }
+
+    // If no changes, still bump patch version
+    return [major, minor, patch + 1];
+  }
+
+  /**
+   * Compare two version tuples
+   * Returns: negative if a < b, 0 if equal, positive if a > b
+   */
+  private compareVersionTuples(a: [number, number, number], b: [number, number, number]): number {
+    if (a[0] !== b[0]) return a[0] - b[0];
+    if (a[1] !== b[1]) return a[1] - b[1];
+    return a[2] - b[2];
+  }
+
+  /**
+   * Create a snapshot of dataset state
+   */
+  private createSnapshot(dataset: Dataset): DatasetSnapshot {
+    const totalSize = dataset.files.reduce((sum, file) => sum + file.size, 0);
+
+    return {
+      files: dataset.files.map((file) => ({ ...file })),
+      metadata: { ...dataset.metadata },
+      config: {
+        name: dataset.name,
+        description: dataset.description,
+        encrypt: dataset.encrypted,
+        accessConditions: dataset.accessConditions,
+        tags: dataset.metadata.keywords || [],
+      },
+      totalSize,
+      fileCount: dataset.files.length,
+    };
+  }
+
+  /**
+   * Compute changes needed for rollback
+   */
+  private computeChangesForRollback(
+    currentDataset: Dataset,
+    targetSnapshot: DatasetSnapshot,
+  ): VersionChanges {
+    const currentCIDs = new Set(currentDataset.files.map((f) => f.cid));
+    const targetCIDs = new Set(targetSnapshot.files.map((f) => f.cid));
+
+    const filesAdded: string[] = [];
+    targetCIDs.forEach((cid) => {
+      if (!currentCIDs.has(cid)) {
+        filesAdded.push(cid);
+      }
+    });
+
+    const filesRemoved: string[] = [];
+    currentCIDs.forEach((cid) => {
+      if (!targetCIDs.has(cid)) {
+        filesRemoved.push(cid);
+      }
+    });
+
+    const metadataChanged =
+      JSON.stringify(currentDataset.metadata) !== JSON.stringify(targetSnapshot.metadata);
+
+    return {
+      filesAdded,
+      filesRemoved,
+      filesModified: [],
+      metadataChanged,
+      configChanged: false,
+      summary: `Rollback to version with ${targetSnapshot.fileCount} files`,
+    };
+  }
+
+  /**
+   * Compute metadata changes between two metadata objects
+   */
+  private computeMetadataChanges(
+    from: DatasetMetadata,
+    to: DatasetMetadata,
+  ): Record<string, { from: unknown; to: unknown }> {
+    const changes: Record<string, { from: unknown; to: unknown }> = {};
+
+    // Compare all metadata fields
+    const allKeys = new Set([...Object.keys(from), ...Object.keys(to)]);
+
+    allKeys.forEach((key) => {
+      const fromValue = (from as any)[key];
+      const toValue = (to as any)[key];
+
+      if (JSON.stringify(fromValue) !== JSON.stringify(toValue)) {
+        changes[key] = { from: fromValue, to: toValue };
+      }
+    });
+
+    return changes;
+  }
+
+  /**
+   * Generate human-readable summary of version differences
+   */
+  private generateDiffSummary(
+    added: number,
+    removed: number,
+    modified: number,
+    metadataChanges: number,
+  ): string {
+    const parts: string[] = [];
+
+    if (added > 0) parts.push(`${added} file(s) added`);
+    if (removed > 0) parts.push(`${removed} file(s) removed`);
+    if (modified > 0) parts.push(`${modified} file(s) modified`);
+    if (metadataChanges > 0) parts.push(`${metadataChanges} metadata field(s) changed`);
+
+    if (parts.length === 0) {
+      return "No changes";
+    }
+
+    return parts.join(", ");
+  }
+
+  /**
+   * Get total number of versions across all datasets
+   */
+  getTotalVersionCount(): number {
+    let count = 0;
+    this.versions.forEach((versions) => {
+      count += versions.length;
+    });
+    return count;
+  }
+
+  /**
+   * Get version count for a specific dataset
+   */
+  getVersionCount(datasetId: string): number {
+    const versions = this.versions.get(datasetId);
+    return versions ? versions.length : 0;
+  }
+
+  /**
+   * Clear all versions (for testing)
+   */
+  clear(): void {
+    this.versions.clear();
+    this.logger.info("All versions cleared");
+  }
+
+  /**
+   * Clear versions for a specific dataset
+   */
+  clearDatasetVersions(datasetId: string): void {
+    this.versions.delete(datasetId);
+    this.logger.info("Versions cleared for dataset", { datasetId });
+  }
+}

--- a/apps/mcp-server/src/services/IDatasetService.ts
+++ b/apps/mcp-server/src/services/IDatasetService.ts
@@ -1,0 +1,214 @@
+/**
+ * Interface for Dataset Service
+ * Defines the contract for dataset management operations including versioning,
+ * batch uploads, and retrieval functionality
+ */
+
+import {
+  Dataset,
+  DatasetConfig,
+  DatasetUpdate,
+  DatasetFilter,
+  DatasetStats,
+  DatasetVersion,
+  VersionChanges,
+  VersionDiff,
+  BatchUploadResult,
+} from "@lighthouse-tooling/types";
+
+/**
+ * Core interface for dataset management operations
+ */
+export interface IDatasetService {
+  /**
+   * Create a new dataset with multiple files uploaded in parallel
+   * @param config - Dataset configuration including name, description, and metadata
+   * @param files - Array of file paths to upload
+   * @param options - Upload options (concurrency, encryption, etc.)
+   * @returns Promise resolving to the created dataset
+   */
+  createDataset(
+    config: DatasetConfig,
+    files: string[],
+    options?: DatasetCreateOptions,
+  ): Promise<Dataset>;
+
+  /**
+   * Get a dataset by ID, optionally at a specific version
+   * @param datasetId - Unique identifier of the dataset
+   * @param version - Optional version string (e.g., "1.0.0")
+   * @returns Promise resolving to the dataset
+   */
+  getDataset(datasetId: string, version?: string): Promise<Dataset>;
+
+  /**
+   * Update an existing dataset
+   * @param datasetId - Unique identifier of the dataset
+   * @param updates - Update parameters (description, metadata, files to add/remove)
+   * @returns Promise resolving to the updated dataset
+   */
+  updateDataset(datasetId: string, updates: DatasetUpdate): Promise<Dataset>;
+
+  /**
+   * List datasets with optional filtering and pagination
+   * @param filter - Optional filter criteria
+   * @returns Promise resolving to array of matching datasets
+   */
+  listDatasets(filter?: DatasetFilter): Promise<Dataset[]>;
+
+  /**
+   * Delete a dataset and all its versions
+   * @param datasetId - Unique identifier of the dataset
+   * @returns Promise resolving to true if deleted successfully
+   */
+  deleteDataset(datasetId: string): Promise<boolean>;
+
+  /**
+   * Create a new version of a dataset with tracked changes
+   * @param datasetId - Unique identifier of the dataset
+   * @param changes - Changes being made in this version
+   * @returns Promise resolving to the new version
+   */
+  createVersion(datasetId: string, changes: VersionChanges): Promise<DatasetVersion>;
+
+  /**
+   * List all versions of a dataset
+   * @param datasetId - Unique identifier of the dataset
+   * @returns Promise resolving to array of versions, newest first
+   */
+  listVersions(datasetId: string): Promise<DatasetVersion[]>;
+
+  /**
+   * Rollback a dataset to a previous version
+   * @param datasetId - Unique identifier of the dataset
+   * @param version - Version string to rollback to (e.g., "1.0.0")
+   * @returns Promise resolving to the dataset at the specified version
+   */
+  rollbackToVersion(datasetId: string, version: string): Promise<Dataset>;
+
+  /**
+   * Compare two versions of a dataset
+   * @param datasetId - Unique identifier of the dataset
+   * @param fromVersion - Starting version for comparison
+   * @param toVersion - Ending version for comparison
+   * @returns Promise resolving to the differences between versions
+   */
+  compareVersions(datasetId: string, fromVersion: string, toVersion: string): Promise<VersionDiff>;
+
+  /**
+   * Add files to an existing dataset
+   * @param datasetId - Unique identifier of the dataset
+   * @param files - Array of file paths to add
+   * @param options - Upload options
+   * @returns Promise resolving to batch upload result
+   */
+  addFilesToDataset(
+    datasetId: string,
+    files: string[],
+    options?: BatchUploadOptions,
+  ): Promise<BatchUploadResult>;
+
+  /**
+   * Remove files from a dataset by CID
+   * @param datasetId - Unique identifier of the dataset
+   * @param cids - Array of CIDs to remove
+   * @returns Promise resolving to the updated dataset
+   */
+  removeFilesFromDataset(datasetId: string, cids: string[]): Promise<Dataset>;
+
+  /**
+   * Get statistics for a dataset
+   * @param datasetId - Unique identifier of the dataset
+   * @returns Promise resolving to dataset statistics
+   */
+  getDatasetStats(datasetId: string): Promise<DatasetStats>;
+
+  /**
+   * Get overall statistics for all datasets
+   * @returns Object containing aggregate statistics
+   */
+  getAllStats(): DatasetServiceStats;
+
+  /**
+   * Clear all datasets (primarily for testing)
+   */
+  clear(): void;
+}
+
+/**
+ * Options for creating a dataset
+ */
+export interface DatasetCreateOptions {
+  /** Number of parallel uploads (default: 5, max: 20) */
+  concurrency?: number;
+  /** Timeout per file upload in milliseconds (default: 30000) */
+  timeout?: number;
+  /** Maximum retry attempts per file (default: 3) */
+  maxRetries?: number;
+  /** Callback for progress updates */
+  onProgress?: (progress: DatasetProgress) => void;
+  /** Whether to continue on individual file failures (default: true) */
+  continueOnError?: boolean;
+}
+
+/**
+ * Options for batch upload operations
+ */
+export interface BatchUploadOptions {
+  /** Number of parallel uploads (default: 5, max: 20) */
+  concurrency?: number;
+  /** Timeout per file upload in milliseconds (default: 30000) */
+  timeout?: number;
+  /** Maximum retry attempts per file (default: 3) */
+  maxRetries?: number;
+  /** Callback for progress updates */
+  onProgress?: (progress: DatasetProgress) => void;
+  /** Whether to create a new version after adding files (default: true) */
+  createVersion?: boolean;
+  /** Whether to continue on individual file failures (default: true) */
+  continueOnError?: boolean;
+}
+
+/**
+ * Progress information for dataset operations
+ */
+export interface DatasetProgress {
+  /** Type of operation */
+  operation: "create" | "update" | "upload" | "delete";
+  /** Total files to process */
+  total: number;
+  /** Files completed */
+  completed: number;
+  /** Files failed */
+  failed: number;
+  /** Current file being processed */
+  currentFile?: string;
+  /** Progress percentage (0-100) */
+  percentage: number;
+  /** Estimated time remaining in milliseconds */
+  estimatedTimeRemaining?: number;
+  /** Current processing rate (files per second) */
+  rate?: number;
+  /** Timestamp of update */
+  timestamp: Date;
+}
+
+/**
+ * Overall statistics for the dataset service
+ */
+export interface DatasetServiceStats {
+  /** Total number of datasets */
+  totalDatasets: number;
+  /** Total number of files across all datasets */
+  totalFiles: number;
+  /** Total size of all files in bytes */
+  totalSize: number;
+  /** Number of encrypted datasets */
+  encryptedDatasets: number;
+  /** Number of total versions across all datasets */
+  totalVersions: number;
+  /** Average files per dataset */
+  averageFilesPerDataset: number;
+  /** Average dataset size in bytes */
+  averageDatasetSize: number;
+}

--- a/apps/mcp-server/src/tests/services/BatchUploadManager.test.ts
+++ b/apps/mcp-server/src/tests/services/BatchUploadManager.test.ts
@@ -1,0 +1,309 @@
+/**
+ * BatchUploadManager tests
+ * Tests for parallel upload with concurrency control and progress tracking
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { BatchUploadManager } from "../../services/BatchUploadManager.js";
+import { MockLighthouseService } from "../../services/MockLighthouseService.js";
+import { createTestFile, cleanupTestFiles } from "../utils/test-helpers.js";
+import { DatasetProgress } from "../../services/IDatasetService.js";
+
+describe("BatchUploadManager", () => {
+  let manager: BatchUploadManager;
+  let lighthouseService: MockLighthouseService;
+  let testFiles: string[];
+
+  beforeEach(async () => {
+    lighthouseService = new MockLighthouseService();
+    manager = new BatchUploadManager(lighthouseService);
+
+    testFiles = [
+      await createTestFile("batch1.txt", "Batch content 1"),
+      await createTestFile("batch2.txt", "Batch content 2"),
+      await createTestFile("batch3.txt", "Batch content 3"),
+      await createTestFile("batch4.txt", "Batch content 4"),
+      await createTestFile("batch5.txt", "Batch content 5"),
+    ];
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+
+  afterEach(async () => {
+    lighthouseService.clear();
+    await cleanupTestFiles();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+  describe("uploadFiles", () => {
+    it("should upload files in parallel", async () => {
+      const result = await manager.uploadFiles(testFiles, {}, { concurrency: 3 });
+
+      expect(result.total).toBe(5);
+      expect(result.successful).toBe(5);
+      expect(result.failed).toBe(0);
+      expect(result.successfulUploads).toHaveLength(5);
+      expect(result.duration).toBeGreaterThan(0);
+    });
+
+    it("should respect concurrency limits", async () => {
+      let maxConcurrent = 0;
+      let currentConcurrent = 0;
+
+      const originalUpload = lighthouseService.uploadFile.bind(lighthouseService);
+      lighthouseService.uploadFile = vi.fn(async (params) => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        const result = await originalUpload(params);
+        currentConcurrent--;
+        return result;
+      });
+
+      await manager.uploadFiles(testFiles, {}, { concurrency: 2 });
+
+      expect(maxConcurrent).toBeLessThanOrEqual(2);
+    });
+
+    it("should track progress during upload", async () => {
+      const progressUpdates: DatasetProgress[] = [];
+
+      await manager.uploadFiles(
+        testFiles,
+        {},
+        {
+          concurrency: 2,
+          onProgress: (progress) => {
+            progressUpdates.push({ ...progress });
+          },
+        },
+      );
+
+      expect(progressUpdates.length).toBeGreaterThan(0);
+      expect(progressUpdates[progressUpdates.length - 1].completed).toBe(5);
+    });
+
+    it("should handle partial failures", async () => {
+      const filesWithInvalid = [...testFiles, "non-existent.txt"];
+
+      const result = await manager.uploadFiles(filesWithInvalid, {});
+
+      expect(result.total).toBe(6);
+      expect(result.successful).toBe(5);
+      expect(result.failed).toBe(1);
+      expect(result.failedUploads).toHaveLength(1);
+      expect(result.failedUploads[0].filePath).toBe("non-existent.txt");
+    });
+
+    it("should calculate average speed", async () => {
+      const result = await manager.uploadFiles(testFiles, {});
+
+      expect(result.averageSpeed).toBeGreaterThan(0);
+    });
+
+    it("should apply encryption config", async () => {
+      const result = await manager.uploadFiles(testFiles, { encrypt: true });
+
+      expect(result.successfulUploads.every((u) => u.encrypted)).toBe(true);
+    });
+
+    it("should apply access conditions", async () => {
+      const accessConditions = [
+        {
+          type: "token_balance" as any,
+          condition: "balance",
+          value: "100",
+        },
+      ];
+
+      const result = await manager.uploadFiles(testFiles, {
+        encrypt: true,
+        accessConditions,
+      });
+
+      expect(result.successfulUploads[0].accessConditions).toEqual(accessConditions);
+    });
+
+    it("should handle timeout", async () => {
+      const result = await manager.uploadFiles([testFiles[0]], {}, { timeout: 1 });
+
+      // Either succeeds quickly or fails with timeout
+      expect(result.total).toBe(1);
+    }, 10000);
+  });
+
+  describe("uploadFilesInBatches", () => {
+    it("should process files in batches", async () => {
+      const manyFiles = await Promise.all(
+        Array.from({ length: 20 }, (_, i) => createTestFile(`batch${i}.txt`, `Content ${i}`)),
+      );
+
+      const result = await manager.uploadFilesInBatches(
+        manyFiles,
+        {},
+        {
+          batchSize: 5,
+          concurrency: 2,
+        },
+      );
+
+      expect(result.total).toBe(20);
+      expect(result.successful).toBe(20);
+      expect(result.failed).toBe(0);
+    }, 60000);
+
+    it("should track overall progress across batches", async () => {
+      const manyFiles = await Promise.all(
+        Array.from({ length: 15 }, (_, i) => createTestFile(`batch${i}.txt`, `Content ${i}`)),
+      );
+
+      const progressUpdates: DatasetProgress[] = [];
+
+      await manager.uploadFilesInBatches(
+        manyFiles,
+        {},
+        {
+          batchSize: 5,
+          concurrency: 2,
+          onProgress: (progress) => {
+            progressUpdates.push({ ...progress });
+          },
+        },
+      );
+
+      expect(progressUpdates.length).toBeGreaterThan(0);
+      const lastUpdate = progressUpdates[progressUpdates.length - 1];
+      expect(lastUpdate.total).toBe(15);
+      expect(lastUpdate.completed).toBe(15);
+    }, 60000);
+
+    it("should handle partial failures across batches", async () => {
+      const manyFiles = await Promise.all(
+        Array.from({ length: 10 }, (_, i) => createTestFile(`batch${i}.txt`, `Content ${i}`)),
+      );
+      manyFiles.push("non-existent-1.txt", "non-existent-2.txt");
+
+      const result = await manager.uploadFilesInBatches(
+        manyFiles,
+        {},
+        {
+          batchSize: 5,
+          concurrency: 2,
+        },
+      );
+
+      expect(result.total).toBe(12);
+      expect(result.successful).toBe(10);
+      expect(result.failed).toBe(2);
+    }, 60000);
+  });
+
+  describe("getOptimalBatchConfig", () => {
+    it("should recommend batching for large datasets", () => {
+      const config = manager.getOptimalBatchConfig(1500);
+
+      expect(config.useBatching).toBe(true);
+      expect(config.batchSize).toBe(50);
+      expect(config.concurrency).toBe(5);
+    });
+
+    it("should recommend parallel upload for medium datasets", () => {
+      const config = manager.getOptimalBatchConfig(500);
+
+      expect(config.useBatching).toBe(false);
+      expect(config.concurrency).toBe(10);
+    });
+
+    it("should recommend default settings for small datasets", () => {
+      const config = manager.getOptimalBatchConfig(50);
+
+      expect(config.useBatching).toBe(false);
+      expect(config.concurrency).toBe(5);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should continue on individual file errors", async () => {
+      const mixedFiles = [testFiles[0], "invalid-1.txt", testFiles[1], "invalid-2.txt"];
+
+      const result = await manager.uploadFiles(mixedFiles, {});
+
+      expect(result.successful).toBe(2);
+      expect(result.failed).toBe(2);
+      expect(result.successfulUploads).toHaveLength(2);
+      expect(result.failedUploads).toHaveLength(2);
+    });
+
+    it("should provide error details for failed uploads", async () => {
+      const result = await manager.uploadFiles(["non-existent.txt"], {});
+
+      expect(result.failedUploads[0].error).toBeDefined();
+      expect(result.failedUploads[0].retryAttempts).toBe(0);
+      expect(result.failedUploads[0].failedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("progress tracking", () => {
+    it("should emit progress events", async () => {
+      const progressEvents: DatasetProgress[] = [];
+
+      manager.on("progress", (progress) => {
+        progressEvents.push(progress);
+      });
+
+      await manager.uploadFiles(testFiles, {}, { concurrency: 2 });
+
+      expect(progressEvents.length).toBeGreaterThan(0);
+      expect(progressEvents[0].operation).toBe("upload");
+      expect(progressEvents[0].total).toBe(5);
+    });
+
+    it("should calculate accurate percentage", async () => {
+      const progressUpdates: DatasetProgress[] = [];
+
+      await manager.uploadFiles(
+        testFiles,
+        {},
+        {
+          onProgress: (progress) => {
+            progressUpdates.push({ ...progress });
+          },
+        },
+      );
+
+      const lastProgress = progressUpdates[progressUpdates.length - 1];
+      expect(lastProgress.percentage).toBe(100);
+    });
+
+    it("should provide rate estimation", async () => {
+      const progressUpdates: DatasetProgress[] = [];
+
+      await manager.uploadFiles(
+        testFiles,
+        {},
+        {
+          onProgress: (progress) => {
+            progressUpdates.push({ ...progress });
+          },
+        },
+      );
+
+      const progressWithRate = progressUpdates.find((p) => p.rate && p.rate > 0);
+      expect(progressWithRate).toBeDefined();
+    });
+  });
+
+  describe("performance", () => {
+    it("should handle 50 files efficiently", async () => {
+      const manyFiles = await Promise.all(
+        Array.from({ length: 50 }, (_, i) => createTestFile(`perf${i}.txt`, `Content ${i}`)),
+      );
+
+      const start = Date.now();
+      const result = await manager.uploadFiles(manyFiles, {}, { concurrency: 10 });
+      const duration = Date.now() - start;
+
+      expect(result.successful).toBe(50);
+      expect(duration).toBeLessThan(30000); // Should complete within 30 seconds
+    }, 60000);
+  });
+});

--- a/apps/mcp-server/src/tests/services/DatasetService.test.ts
+++ b/apps/mcp-server/src/tests/services/DatasetService.test.ts
@@ -1,0 +1,422 @@
+/**
+ * DatasetService tests
+ * Comprehensive tests for dataset management with versioning and parallel uploads
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DatasetService } from "../../services/DatasetService.js";
+import { MockLighthouseService } from "../../services/MockLighthouseService.js";
+import { createTestFile, cleanupTestFiles } from "../utils/test-helpers.js";
+import { DatasetConfig, DatasetUpdate } from "@lighthouse-tooling/types";
+
+describe("DatasetService", () => {
+  let service: DatasetService;
+  let lighthouseService: MockLighthouseService;
+  let testFiles: string[];
+
+  beforeEach(async () => {
+    lighthouseService = new MockLighthouseService();
+    service = new DatasetService(lighthouseService);
+
+    // Create test files
+    testFiles = [
+      await createTestFile("test1.txt", "Test content 1"),
+      await createTestFile("test2.txt", "Test content 2"),
+      await createTestFile("test3.txt", "Test content 3"),
+    ];
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+
+  afterEach(async () => {
+    service.clear();
+    lighthouseService.clear();
+    await cleanupTestFiles();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+  describe("createDataset", () => {
+    it("should create dataset with parallel uploads", async () => {
+      const config: DatasetConfig = {
+        name: "Test Dataset",
+        description: "A test dataset",
+      };
+
+      const dataset = await service.createDataset(config, testFiles);
+
+      expect(dataset.id).toBeDefined();
+      expect(dataset.name).toBe("Test Dataset");
+      expect(dataset.version).toBe("1.0.0");
+      expect(dataset.files).toHaveLength(3);
+      expect(dataset.createdAt).toBeInstanceOf(Date);
+    });
+
+    it("should create encrypted dataset", async () => {
+      const config: DatasetConfig = {
+        name: "Encrypted Dataset",
+        encrypt: true,
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      expect(dataset.encrypted).toBe(true);
+      expect(dataset.files[0].encrypted).toBe(true);
+    });
+
+    it("should create dataset with metadata", async () => {
+      const config: DatasetConfig = {
+        name: "Dataset with Metadata",
+        metadata: {
+          author: "Test Author",
+          license: "MIT",
+          category: "test",
+          keywords: ["test", "dataset"],
+        },
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      expect(dataset.metadata.author).toBe("Test Author");
+      expect(dataset.metadata.license).toBe("MIT");
+      expect(dataset.metadata.keywords).toEqual(["test", "dataset"]);
+    });
+
+    it("should handle large file count with configurable concurrency", async () => {
+      const manyFiles = await Promise.all(
+        Array.from({ length: 20 }, (_, i) => createTestFile(`large${i}.txt`, `Content ${i}`)),
+      );
+
+      const config: DatasetConfig = {
+        name: "Large Dataset",
+      };
+
+      const dataset = await service.createDataset(config, manyFiles, { concurrency: 10 });
+
+      expect(dataset.files).toHaveLength(20);
+    }, 30000); // 30 second timeout for large operation
+
+    it("should continue on individual file failures", async () => {
+      const invalidFiles = [...testFiles, "non-existent-file.txt"];
+
+      const config: DatasetConfig = {
+        name: "Partial Success Dataset",
+      };
+
+      const dataset = await service.createDataset(config, invalidFiles, {
+        continueOnError: true,
+      });
+
+      // Should have created dataset with successful files
+      expect(dataset.files.length).toBeGreaterThan(0);
+      expect(dataset.files.length).toBeLessThan(invalidFiles.length);
+    });
+
+    it("should throw error for duplicate dataset name", async () => {
+      const config: DatasetConfig = {
+        name: "Duplicate Dataset",
+      };
+
+      await service.createDataset(config, [testFiles[0]]);
+
+      await expect(service.createDataset(config, [testFiles[1]])).rejects.toThrow("already exists");
+    });
+
+    it("should throw error for empty files array", async () => {
+      const config: DatasetConfig = {
+        name: "Empty Dataset",
+      };
+
+      await expect(service.createDataset(config, [])).rejects.toThrow(
+        "At least one file is required",
+      );
+    });
+  });
+
+  describe("getDataset", () => {
+    it("should retrieve dataset by ID", async () => {
+      const config: DatasetConfig = {
+        name: "Test Dataset",
+      };
+
+      const created = await service.createDataset(config, [testFiles[0]]);
+      const retrieved = await service.getDataset(created.id);
+
+      expect(retrieved.id).toBe(created.id);
+      expect(retrieved.name).toBe("Test Dataset");
+    });
+
+    it("should retrieve dataset at specific version", async () => {
+      const config: DatasetConfig = {
+        name: "Versioned Dataset",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      // Update to create new version
+      await service.updateDataset(dataset.id, {
+        description: "Updated description",
+      });
+
+      // Get original version
+      const originalVersion = await service.getDataset(dataset.id, "1.0.0");
+      expect(originalVersion.version).toBe("1.0.0");
+    });
+
+    it("should throw error for non-existent dataset", async () => {
+      await expect(service.getDataset("nonexistent-id")).rejects.toThrow("Dataset not found");
+    });
+  });
+
+  describe("updateDataset", () => {
+    it("should update dataset description", async () => {
+      const config: DatasetConfig = {
+        name: "Original Dataset",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      const updated = await service.updateDataset(dataset.id, {
+        description: "Updated description",
+      });
+
+      expect(updated.description).toBe("Updated description");
+      expect(updated.version).not.toBe(dataset.version);
+    });
+
+    it("should add files to dataset", async () => {
+      const config: DatasetConfig = {
+        name: "Growing Dataset",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+      const originalCount = dataset.files.length;
+
+      const updated = await service.updateDataset(dataset.id, {
+        addFiles: [testFiles[1], testFiles[2]],
+      });
+
+      expect(updated.files.length).toBe(originalCount + 2);
+    });
+
+    it("should remove files from dataset", async () => {
+      const config: DatasetConfig = {
+        name: "Shrinking Dataset",
+      };
+
+      const dataset = await service.createDataset(config, testFiles);
+      const cidsToRemove = [dataset.files[0].cid];
+
+      const updated = await service.updateDataset(dataset.id, {
+        removeFiles: cidsToRemove,
+      });
+
+      expect(updated.files.length).toBe(testFiles.length - 1);
+      expect(updated.files.find((f) => f.cid === cidsToRemove[0])).toBeUndefined();
+    });
+
+    it("should update metadata", async () => {
+      const config: DatasetConfig = {
+        name: "Metadata Dataset",
+        metadata: { author: "Original Author" },
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      const updated = await service.updateDataset(dataset.id, {
+        metadata: { author: "Updated Author", license: "Apache-2.0" },
+      });
+
+      expect(updated.metadata.author).toBe("Updated Author");
+      expect(updated.metadata.license).toBe("Apache-2.0");
+    });
+
+    it("should create new version on update", async () => {
+      const config: DatasetConfig = {
+        name: "Version Test Dataset",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+      const originalVersion = dataset.version;
+
+      await service.updateDataset(dataset.id, {
+        description: "Updated",
+      });
+
+      const versions = await service.listVersions(dataset.id);
+      expect(versions.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe("listDatasets", () => {
+    beforeEach(async () => {
+      await service.createDataset(
+        {
+          name: "Dataset 1",
+          encrypt: true,
+          metadata: { category: "research", keywords: ["test", "data"] },
+        },
+        [testFiles[0]],
+      );
+
+      await service.createDataset(
+        {
+          name: "Dataset 2",
+          encrypt: false,
+          metadata: { category: "backup", keywords: ["backup"] },
+        },
+        [testFiles[1]],
+      );
+    });
+
+    it("should list all datasets", async () => {
+      const datasets = await service.listDatasets();
+      expect(datasets.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should filter by encryption status", async () => {
+      const encrypted = await service.listDatasets({ encrypted: true });
+      expect(encrypted.length).toBeGreaterThan(0);
+      expect(encrypted.every((d) => d.encrypted)).toBe(true);
+    });
+
+    it("should filter by name pattern", async () => {
+      const filtered = await service.listDatasets({ namePattern: "Dataset 1" });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].name).toBe("Dataset 1");
+    });
+
+    it("should filter by tags/keywords", async () => {
+      const filtered = await service.listDatasets({ tags: ["test"] });
+      expect(filtered.length).toBeGreaterThan(0);
+    });
+
+    it("should filter by category", async () => {
+      const filtered = await service.listDatasets({ category: "research" });
+      expect(filtered.length).toBeGreaterThan(0);
+      expect(filtered[0].metadata.category).toBe("research");
+    });
+
+    it("should support pagination", async () => {
+      const page1 = await service.listDatasets({ limit: 1, offset: 0 });
+      const page2 = await service.listDatasets({ limit: 1, offset: 1 });
+
+      expect(page1).toHaveLength(1);
+      expect(page2).toHaveLength(1);
+      expect(page1[0].id).not.toBe(page2[0].id);
+    });
+  });
+
+  describe("deleteDataset", () => {
+    it("should delete dataset", async () => {
+      const config: DatasetConfig = {
+        name: "To Delete",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      const result = await service.deleteDataset(dataset.id);
+      expect(result).toBe(true);
+
+      await expect(service.getDataset(dataset.id)).rejects.toThrow("Dataset not found");
+    });
+
+    it("should return false for non-existent dataset", async () => {
+      const result = await service.deleteDataset("nonexistent-id");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("versioning", () => {
+    it("should list versions", async () => {
+      const config: DatasetConfig = {
+        name: "Versioned Dataset",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+
+      // Create more versions
+      await service.updateDataset(dataset.id, { description: "Update 1" });
+      await service.updateDataset(dataset.id, { description: "Update 2" });
+
+      const versions = await service.listVersions(dataset.id);
+      expect(versions.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("should rollback to previous version", async () => {
+      const config: DatasetConfig = {
+        name: "Rollback Dataset",
+        description: "Original",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+      const originalVersion = dataset.version;
+
+      await service.updateDataset(dataset.id, { description: "Modified" });
+
+      const rolledBack = await service.rollbackToVersion(dataset.id, originalVersion);
+      expect(rolledBack.description).toBe("Original");
+    });
+
+    it("should compare versions", async () => {
+      const config: DatasetConfig = {
+        name: "Compare Dataset",
+      };
+
+      const dataset = await service.createDataset(config, [testFiles[0]]);
+      const v1 = dataset.version;
+
+      await service.updateDataset(dataset.id, { addFiles: [testFiles[1]] });
+      const updated = await service.getDataset(dataset.id);
+      const v2 = updated.version;
+
+      const diff = await service.compareVersions(dataset.id, v1, v2);
+      expect(diff.filesAdded.length).toBe(1);
+      expect(diff.summary).toContain("file");
+    });
+  });
+
+  describe("statistics", () => {
+    it("should get dataset statistics", async () => {
+      const config: DatasetConfig = {
+        name: "Stats Dataset",
+      };
+
+      const dataset = await service.createDataset(config, testFiles);
+
+      const stats = await service.getDatasetStats(dataset.id);
+
+      expect(stats.fileCount).toBe(testFiles.length);
+      expect(stats.totalSize).toBeGreaterThan(0);
+      expect(stats.averageFileSize).toBeGreaterThan(0);
+      expect(stats.version).toBe(dataset.version);
+    });
+
+    it("should get overall service statistics", () => {
+      const stats = service.getAllStats();
+
+      expect(stats).toHaveProperty("totalDatasets");
+      expect(stats).toHaveProperty("totalFiles");
+      expect(stats).toHaveProperty("totalSize");
+      expect(stats).toHaveProperty("totalVersions");
+    });
+  });
+
+  describe("performance", () => {
+    it("should handle 100 files efficiently", async () => {
+      const manyFiles = await Promise.all(
+        Array.from({ length: 100 }, (_, i) => createTestFile(`perf${i}.txt`, `Content ${i}`)),
+      );
+
+      const config: DatasetConfig = {
+        name: "Performance Dataset",
+      };
+
+      const start = Date.now();
+      const dataset = await service.createDataset(config, manyFiles, { concurrency: 10 });
+      const duration = Date.now() - start;
+
+      expect(dataset.files).toHaveLength(100);
+      expect(duration).toBeLessThan(60000); // Should complete within 60 seconds
+    }, 120000); // 2 minute timeout
+  });
+});

--- a/apps/mcp-server/src/tests/services/DatasetVersionManager.test.ts
+++ b/apps/mcp-server/src/tests/services/DatasetVersionManager.test.ts
@@ -1,0 +1,427 @@
+/**
+ * DatasetVersionManager tests
+ * Tests for semantic versioning and rollback capabilities
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { DatasetVersionManager } from "../../services/DatasetVersionManager.js";
+import { Dataset, VersionChanges } from "@lighthouse-tooling/types";
+
+describe("DatasetVersionManager", () => {
+  let manager: DatasetVersionManager;
+  let mockDataset: Dataset;
+
+  beforeEach(() => {
+    manager = new DatasetVersionManager();
+
+    mockDataset = {
+      id: "dataset-1",
+      name: "Test Dataset",
+      description: "Test description",
+      files: [
+        {
+          cid: "QmTest1",
+          size: 100,
+          encrypted: false,
+          uploadedAt: new Date(),
+          originalPath: "test1.txt",
+        },
+      ],
+      metadata: {
+        author: "Test Author",
+        license: "MIT",
+      },
+      version: "1.0.0",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      encrypted: false,
+    };
+  });
+
+  describe("createVersion", () => {
+    it("should create initial version", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Initial version",
+      };
+
+      const version = await manager.createVersion(mockDataset, changes);
+
+      expect(version.id).toBeDefined();
+      expect(version.datasetId).toBe(mockDataset.id);
+      expect(version.version).toBe("1.0.0");
+      expect(version.snapshot.files).toHaveLength(1);
+    });
+
+    it("should bump minor version when files added", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest2"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Added file",
+      };
+
+      const version = await manager.createVersion(mockDataset, changes);
+
+      expect(version.version).toBe("1.1.0");
+    });
+
+    it("should bump major version when files removed", async () => {
+      const changes: VersionChanges = {
+        filesAdded: [],
+        filesRemoved: ["QmTest1"],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Removed file",
+      };
+
+      const version = await manager.createVersion(mockDataset, changes);
+
+      expect(version.version).toBe("2.0.0");
+    });
+
+    it("should bump patch version for metadata changes", async () => {
+      const changes: VersionChanges = {
+        filesAdded: [],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: true,
+        configChanged: false,
+        summary: "Updated metadata",
+      };
+
+      const version = await manager.createVersion(mockDataset, changes);
+
+      expect(version.version).toBe("1.0.1");
+    });
+
+    it("should store snapshot correctly", async () => {
+      const changes: VersionChanges = {
+        filesAdded: [],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Test snapshot",
+      };
+
+      const version = await manager.createVersion(mockDataset, changes);
+
+      expect(version.snapshot.files).toHaveLength(1);
+      expect(version.snapshot.fileCount).toBe(1);
+      expect(version.snapshot.totalSize).toBe(100);
+      expect(version.snapshot.metadata).toEqual(mockDataset.metadata);
+    });
+  });
+
+  describe("listVersions", () => {
+    it("should list versions in descending order", async () => {
+      const changes1: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Version 1",
+      };
+
+      const changes2: VersionChanges = {
+        filesAdded: ["QmTest2"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Version 2",
+      };
+
+      await manager.createVersion(mockDataset, changes1);
+
+      mockDataset.version = "1.0.0";
+      await manager.createVersion(mockDataset, changes2);
+
+      const versions = manager.listVersions(mockDataset.id);
+
+      expect(versions.length).toBe(2);
+      expect(versions[0].version).toBe("1.1.0");
+      expect(versions[1].version).toBe("1.0.0");
+    });
+
+    it("should return empty array for dataset with no versions", () => {
+      const versions = manager.listVersions("nonexistent-dataset");
+      expect(versions).toEqual([]);
+    });
+  });
+
+  describe("getVersion", () => {
+    it("should retrieve specific version", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Test version",
+      };
+
+      await manager.createVersion(mockDataset, changes);
+
+      const version = manager.getVersion(mockDataset.id, "1.0.0");
+
+      expect(version).toBeDefined();
+      expect(version?.version).toBe("1.0.0");
+    });
+
+    it("should return undefined for non-existent version", () => {
+      const version = manager.getVersion(mockDataset.id, "99.99.99");
+      expect(version).toBeUndefined();
+    });
+  });
+
+  describe("rollbackToVersion", () => {
+    it("should rollback dataset to previous version", async () => {
+      const changes1: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Initial version",
+      };
+
+      const version1 = await manager.createVersion(mockDataset, changes1);
+
+      // Modify dataset
+      mockDataset.files.push({
+        cid: "QmTest2",
+        size: 200,
+        encrypted: false,
+        uploadedAt: new Date(),
+        originalPath: "test2.txt",
+      });
+      mockDataset.version = "1.0.0";
+
+      const changes2: VersionChanges = {
+        filesAdded: ["QmTest2"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Added file",
+      };
+
+      await manager.createVersion(mockDataset, changes2);
+
+      // Rollback
+      const rolledBack = await manager.rollbackToVersion(mockDataset, "1.0.0");
+
+      expect(rolledBack.files).toHaveLength(1);
+      expect(rolledBack.files[0].cid).toBe("QmTest1");
+    });
+
+    it("should throw error for non-existent version", async () => {
+      await expect(manager.rollbackToVersion(mockDataset, "99.99.99")).rejects.toThrow(
+        "Version 99.99.99 not found",
+      );
+    });
+  });
+
+  describe("compareVersions", () => {
+    it("should compare versions and show differences", async () => {
+      const changes1: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Initial version",
+      };
+
+      await manager.createVersion(mockDataset, changes1);
+
+      mockDataset.files.push({
+        cid: "QmTest2",
+        size: 200,
+        encrypted: false,
+        uploadedAt: new Date(),
+        originalPath: "test2.txt",
+      });
+      mockDataset.version = "1.0.0";
+
+      const changes2: VersionChanges = {
+        filesAdded: ["QmTest2"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Added file",
+      };
+
+      await manager.createVersion(mockDataset, changes2);
+
+      const diff = manager.compareVersions(mockDataset.id, "1.0.0", "1.1.0");
+
+      expect(diff.filesAdded.length).toBe(1);
+      expect(diff.filesAdded[0].cid).toBe("QmTest2");
+      expect(diff.summary).toContain("1 file(s) added");
+    });
+
+    it("should detect removed files", async () => {
+      mockDataset.files = [
+        {
+          cid: "QmTest1",
+          size: 100,
+          encrypted: false,
+          uploadedAt: new Date(),
+          originalPath: "test1.txt",
+        },
+        {
+          cid: "QmTest2",
+          size: 200,
+          encrypted: false,
+          uploadedAt: new Date(),
+          originalPath: "test2.txt",
+        },
+      ];
+
+      const changes1: VersionChanges = {
+        filesAdded: ["QmTest1", "QmTest2"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Two files",
+      };
+
+      await manager.createVersion(mockDataset, changes1);
+
+      mockDataset.files = [mockDataset.files[0]];
+      mockDataset.version = "1.0.0";
+
+      const changes2: VersionChanges = {
+        filesAdded: [],
+        filesRemoved: ["QmTest2"],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Removed file",
+      };
+
+      await manager.createVersion(mockDataset, changes2);
+
+      const diff = manager.compareVersions(mockDataset.id, "1.0.0", "2.0.0");
+
+      expect(diff.filesRemoved.length).toBe(1);
+      expect(diff.filesRemoved[0].cid).toBe("QmTest2");
+    });
+
+    it("should detect metadata changes", async () => {
+      const changes1: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Initial",
+      };
+
+      await manager.createVersion(mockDataset, changes1);
+
+      mockDataset.metadata.author = "New Author";
+      mockDataset.version = "1.0.0";
+
+      const changes2: VersionChanges = {
+        filesAdded: [],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: true,
+        configChanged: false,
+        summary: "Metadata changed",
+      };
+
+      await manager.createVersion(mockDataset, changes2);
+
+      const diff = manager.compareVersions(mockDataset.id, "1.0.0", "1.0.1");
+
+      expect(Object.keys(diff.metadataChanges).length).toBeGreaterThan(0);
+      expect(diff.summary).toContain("metadata");
+    });
+  });
+
+  describe("utility methods", () => {
+    it("should get total version count", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Test",
+      };
+
+      await manager.createVersion(mockDataset, changes);
+      await manager.createVersion(mockDataset, changes);
+
+      const count = manager.getTotalVersionCount();
+      expect(count).toBe(2);
+    });
+
+    it("should get version count for specific dataset", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Test",
+      };
+
+      await manager.createVersion(mockDataset, changes);
+
+      const count = manager.getVersionCount(mockDataset.id);
+      expect(count).toBe(1);
+    });
+
+    it("should clear all versions", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Test",
+      };
+
+      await manager.createVersion(mockDataset, changes);
+
+      manager.clear();
+
+      const count = manager.getTotalVersionCount();
+      expect(count).toBe(0);
+    });
+
+    it("should clear versions for specific dataset", async () => {
+      const changes: VersionChanges = {
+        filesAdded: ["QmTest1"],
+        filesRemoved: [],
+        filesModified: [],
+        metadataChanged: false,
+        configChanged: false,
+        summary: "Test",
+      };
+
+      await manager.createVersion(mockDataset, changes);
+
+      manager.clearDatasetVersions(mockDataset.id);
+
+      const count = manager.getVersionCount(mockDataset.id);
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/apps/mcp-server/src/tests/tools/LighthouseCreateDatasetTool.test.ts
+++ b/apps/mcp-server/src/tests/tools/LighthouseCreateDatasetTool.test.ts
@@ -1,0 +1,307 @@
+/**
+ * LighthouseCreateDatasetTool tests
+ * Tests for the MCP dataset creation tool
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { LighthouseCreateDatasetTool } from "../../tools/LighthouseCreateDatasetTool.js";
+import { DatasetService } from "../../services/DatasetService.js";
+import { MockLighthouseService } from "../../services/MockLighthouseService.js";
+import { createTestFile, cleanupTestFiles } from "../utils/test-helpers.js";
+
+describe("LighthouseCreateDatasetTool", () => {
+  let tool: LighthouseCreateDatasetTool;
+  let datasetService: DatasetService;
+  let lighthouseService: MockLighthouseService;
+  let testFiles: string[];
+
+  beforeEach(async () => {
+    lighthouseService = new MockLighthouseService();
+    datasetService = new DatasetService(lighthouseService);
+    tool = new LighthouseCreateDatasetTool(datasetService);
+
+    testFiles = [
+      await createTestFile("tool-test1.txt", "Tool test content 1"),
+      await createTestFile("tool-test2.txt", "Tool test content 2"),
+    ];
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+
+  afterEach(async () => {
+    datasetService.clear();
+    lighthouseService.clear();
+    await cleanupTestFiles();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+  describe("getDefinition", () => {
+    it("should return valid tool definition", () => {
+      const definition = LighthouseCreateDatasetTool.getDefinition();
+
+      expect(definition.name).toBe("lighthouse_create_dataset");
+      expect(definition.description).toBeDefined();
+      expect(definition.inputSchema).toBeDefined();
+      expect(definition.inputSchema.type).toBe("object");
+      expect(definition.inputSchema.required).toContain("name");
+      expect(definition.inputSchema.required).toContain("files");
+    });
+
+    it("should define all required properties", () => {
+      const definition = LighthouseCreateDatasetTool.getDefinition();
+      const properties = definition.inputSchema.properties;
+
+      expect(properties.name).toBeDefined();
+      expect(properties.files).toBeDefined();
+      expect(properties.description).toBeDefined();
+      expect(properties.metadata).toBeDefined();
+      expect(properties.encrypt).toBeDefined();
+      expect(properties.concurrency).toBeDefined();
+    });
+  });
+
+  describe("execute", () => {
+    it("should create dataset successfully", async () => {
+      const args = {
+        name: "Test Dataset",
+        description: "A test dataset",
+        files: testFiles,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect((result.data as any).dataset.name).toBe("Test Dataset");
+      expect((result.data as any).dataset.fileCount).toBe(2);
+      expect((result.data as any).dataset.version).toBe("1.0.0");
+    });
+
+    it("should create encrypted dataset", async () => {
+      const args = {
+        name: "Encrypted Dataset",
+        files: [testFiles[0]],
+        encrypt: true,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).dataset.encrypted).toBe(true);
+    });
+
+    it("should include metadata in created dataset", async () => {
+      const args = {
+        name: "Dataset with Metadata",
+        files: [testFiles[0]],
+        metadata: {
+          author: "Test Author",
+          license: "MIT",
+          category: "test",
+          keywords: ["test", "dataset"],
+        },
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(true);
+      const dataset = (result.data as any).dataset;
+      // Metadata should be present in the created dataset
+      expect(dataset).toBeDefined();
+    });
+
+    it("should support custom concurrency", async () => {
+      const args = {
+        name: "Custom Concurrency Dataset",
+        files: testFiles,
+        concurrency: 10,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).dataset.fileCount).toBe(2);
+    });
+
+    it("should include performance metrics", async () => {
+      const args = {
+        name: "Performance Test Dataset",
+        files: testFiles,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).executionTimeMs).toBeDefined();
+      expect((result.data as any).performance).toBeDefined();
+      expect((result.data as any).performance.filesPerSecond).toBeDefined();
+    });
+  });
+
+  describe("validation", () => {
+    it("should reject missing name", async () => {
+      const args = {
+        files: testFiles,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("name is required");
+    });
+
+    it("should reject empty name", async () => {
+      const args = {
+        name: "",
+        files: testFiles,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("name cannot be empty");
+    });
+
+    it("should reject missing files", async () => {
+      const args = {
+        name: "Test Dataset",
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("files is required");
+    });
+
+    it("should reject empty files array", async () => {
+      const args = {
+        name: "Test Dataset",
+        files: [],
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("files array cannot be empty");
+    });
+
+    it("should reject invalid concurrency", async () => {
+      const args = {
+        name: "Test Dataset",
+        files: testFiles,
+        concurrency: 25, // Max is 20
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("concurrency");
+    });
+
+    it("should reject access conditions without encryption", async () => {
+      const args = {
+        name: "Test Dataset",
+        files: testFiles,
+        encrypt: false,
+        accessConditions: [
+          {
+            type: "token_balance",
+            condition: "balance",
+            value: "100",
+          },
+        ],
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Access conditions require encryption");
+    });
+
+    it("should reject too many files", async () => {
+      const args = {
+        name: "Too Many Files",
+        files: Array(10001).fill("dummy.txt"),
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Maximum 10,000 files");
+    });
+
+    it("should reject name that's too long", async () => {
+      const args = {
+        name: "A".repeat(300),
+        files: testFiles,
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("less than 255 characters");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle service errors gracefully", async () => {
+      // Create a dataset with duplicate name first
+      await tool.execute({
+        name: "Duplicate Dataset",
+        files: testFiles,
+      });
+
+      // Try to create again with same name
+      const result = await tool.execute({
+        name: "Duplicate Dataset",
+        files: testFiles,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("already exists");
+    });
+
+    it("should include execution time even on error", async () => {
+      const result = await tool.execute({
+        name: "", // Invalid
+        files: testFiles,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.executionTime).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("integration", () => {
+    it("should create dataset that can be retrieved", async () => {
+      const args = {
+        name: "Integration Test Dataset",
+        files: testFiles,
+      };
+
+      const createResult = await tool.execute(args);
+      expect(createResult.success).toBe(true);
+
+      const datasetId = (createResult.data as any).dataset.id;
+      const dataset = await datasetService.getDataset(datasetId);
+
+      expect(dataset.id).toBe(datasetId);
+      expect(dataset.name).toBe("Integration Test Dataset");
+      expect(dataset.files).toHaveLength(2);
+    });
+
+    it("should create initial version automatically", async () => {
+      const args = {
+        name: "Versioned Dataset",
+        files: testFiles,
+      };
+
+      const createResult = await tool.execute(args);
+      const datasetId = (createResult.data as any).dataset.id;
+
+      const versions = await datasetService.listVersions(datasetId);
+      expect(versions).toHaveLength(1);
+      expect(versions[0].version).toBe("1.0.0");
+    });
+  });
+});

--- a/apps/mcp-server/src/tools/LighthouseCreateDatasetTool.ts
+++ b/apps/mcp-server/src/tools/LighthouseCreateDatasetTool.ts
@@ -1,0 +1,430 @@
+/**
+ * Lighthouse Create Dataset Tool
+ * MCP tool for creating datasets with parallel file uploads and progress tracking
+ */
+
+import { Logger } from "@lighthouse-tooling/shared";
+import {
+  MCPToolDefinition,
+  ExecutionTimeCategory,
+  AccessCondition,
+  DatasetConfig,
+} from "@lighthouse-tooling/types";
+import { IDatasetService, DatasetCreateOptions } from "../services/IDatasetService.js";
+import { ProgressAwareToolResult } from "./types.js";
+
+/**
+ * Input parameters for lighthouse_create_dataset tool
+ */
+interface CreateDatasetParams {
+  name: string;
+  description?: string;
+  files: string[];
+  metadata?: {
+    author?: string;
+    license?: string;
+    category?: string;
+    keywords?: string[];
+    custom?: Record<string, unknown>;
+  };
+  encrypt?: boolean;
+  accessConditions?: AccessCondition[];
+  tags?: string[];
+  concurrency?: number;
+  timeout?: number;
+  maxRetries?: number;
+  continueOnError?: boolean;
+}
+
+/**
+ * MCP tool for creating datasets with multiple files
+ */
+export class LighthouseCreateDatasetTool {
+  private service: IDatasetService;
+  private logger: Logger;
+
+  constructor(service: IDatasetService, logger?: Logger) {
+    this.service = service;
+    this.logger =
+      logger || Logger.getInstance({ level: "info", component: "LighthouseCreateDatasetTool" });
+  }
+
+  /**
+   * Get tool definition for MCP
+   */
+  static getDefinition(): MCPToolDefinition {
+    return {
+      name: "lighthouse_create_dataset",
+      description:
+        "Create a managed dataset with multiple files uploaded in parallel. Supports progress tracking, partial success handling, and automatic versioning. Efficiently handles 1000+ files with configurable concurrency.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Unique name for the dataset",
+            minLength: 1,
+          },
+          description: {
+            type: "string",
+            description: "Optional description of the dataset contents and purpose",
+          },
+          files: {
+            type: "array",
+            description: "Array of file paths to upload to the dataset",
+            items: { type: "string", description: "File path" },
+          },
+          metadata: {
+            type: "object",
+            description: "Rich metadata for the dataset",
+            properties: {
+              author: {
+                type: "string",
+                description: "Author or creator of the dataset",
+              },
+              license: {
+                type: "string",
+                description: "License information (e.g., MIT, Apache-2.0)",
+              },
+              category: {
+                type: "string",
+                description: "Category or domain (e.g., research, backup, media)",
+              },
+              keywords: {
+                type: "array",
+                description: "Search keywords for dataset discovery",
+                items: { type: "string", description: "Keyword" },
+              },
+              custom: {
+                type: "object",
+                description: "Custom metadata properties",
+              },
+            },
+          },
+          encrypt: {
+            type: "boolean",
+            description: "Whether to encrypt all files in the dataset",
+            default: false,
+          },
+          accessConditions: {
+            type: "array",
+            description: "Access control conditions for encrypted datasets",
+            items: {
+              type: "object",
+              description: "Access condition",
+              properties: {
+                type: { type: "string", description: "Condition type" },
+                condition: { type: "string", description: "Condition name" },
+                value: { type: "string", description: "Condition value" },
+              },
+              required: ["type", "condition", "value"],
+            },
+          },
+          tags: {
+            type: "array",
+            description: "Tags for organization and filtering",
+            items: { type: "string", description: "Tag" },
+          },
+          concurrency: {
+            type: "number",
+            description: "Number of parallel uploads (default: 5, max: 20)",
+            default: 5,
+            minimum: 1,
+            maximum: 20,
+          },
+          timeout: {
+            type: "number",
+            description: "Timeout per file upload in milliseconds (default: 30000)",
+            default: 30000,
+          },
+          maxRetries: {
+            type: "number",
+            description: "Maximum retry attempts per file (default: 3)",
+            default: 3,
+            minimum: 0,
+            maximum: 10,
+          },
+          continueOnError: {
+            type: "boolean",
+            description:
+              "Continue creating dataset even if some files fail to upload (default: true)",
+            default: true,
+          },
+        },
+        required: ["name", "files"],
+        additionalProperties: false,
+      },
+      requiresAuth: true,
+      supportsBatch: false,
+      executionTime: ExecutionTimeCategory.SLOW,
+    };
+  }
+
+  /**
+   * Validate input parameters
+   */
+  private async validateParams(params: CreateDatasetParams): Promise<string | null> {
+    // Check required parameters
+    if (!params.name || typeof params.name !== "string") {
+      return "name is required and must be a string";
+    }
+
+    if (params.name.trim().length === 0) {
+      return "name cannot be empty";
+    }
+
+    if (params.name.length > 255) {
+      return "name must be less than 255 characters";
+    }
+
+    if (!params.files || !Array.isArray(params.files)) {
+      return "files is required and must be an array";
+    }
+
+    if (params.files.length === 0) {
+      return "files array cannot be empty";
+    }
+
+    if (params.files.length > 10000) {
+      return "Maximum 10,000 files per dataset";
+    }
+
+    // Validate files are strings
+    for (let i = 0; i < params.files.length; i++) {
+      const file = params.files[i];
+      if (typeof file !== "string") {
+        return `files[${i}] must be a string`;
+      }
+
+      if (file.trim().length === 0) {
+        return `files[${i}] cannot be empty`;
+      }
+    }
+
+    // Validate optional parameters
+    if (params.description !== undefined && typeof params.description !== "string") {
+      return "description must be a string";
+    }
+
+    if (params.encrypt !== undefined && typeof params.encrypt !== "boolean") {
+      return "encrypt must be a boolean";
+    }
+
+    if (params.concurrency !== undefined) {
+      if (typeof params.concurrency !== "number") {
+        return "concurrency must be a number";
+      }
+      if (params.concurrency < 1 || params.concurrency > 20) {
+        return "concurrency must be between 1 and 20";
+      }
+    }
+
+    if (params.timeout !== undefined) {
+      if (typeof params.timeout !== "number") {
+        return "timeout must be a number";
+      }
+      if (params.timeout < 1000) {
+        return "timeout must be at least 1000ms";
+      }
+    }
+
+    if (params.maxRetries !== undefined) {
+      if (typeof params.maxRetries !== "number") {
+        return "maxRetries must be a number";
+      }
+      if (params.maxRetries < 0 || params.maxRetries > 10) {
+        return "maxRetries must be between 0 and 10";
+      }
+    }
+
+    // Validate access conditions if provided
+    if (params.accessConditions) {
+      if (!Array.isArray(params.accessConditions)) {
+        return "accessConditions must be an array";
+      }
+
+      for (let i = 0; i < params.accessConditions.length; i++) {
+        const condition = params.accessConditions[i];
+        if (!condition || typeof condition !== "object") {
+          return `accessConditions[${i}] must be an object`;
+        }
+        if (!condition.type || !condition.condition || !condition.value) {
+          return `accessConditions[${i}] must have type, condition, and value fields`;
+        }
+      }
+
+      // If access conditions specified, encryption must be enabled
+      if (params.accessConditions.length > 0 && !params.encrypt) {
+        return "Access conditions require encryption to be enabled";
+      }
+    }
+
+    // Validate metadata if provided
+    if (params.metadata) {
+      if (typeof params.metadata !== "object") {
+        return "metadata must be an object";
+      }
+
+      if (params.metadata.keywords && !Array.isArray(params.metadata.keywords)) {
+        return "metadata.keywords must be an array";
+      }
+    }
+
+    // Validate tags if provided
+    if (params.tags) {
+      if (!Array.isArray(params.tags)) {
+        return "tags must be an array";
+      }
+
+      for (let i = 0; i < params.tags.length; i++) {
+        if (typeof params.tags[i] !== "string") {
+          return `tags[${i}] must be a string`;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Execute the create dataset operation
+   */
+  async execute(args: Record<string, unknown>): Promise<ProgressAwareToolResult> {
+    const startTime = Date.now();
+
+    try {
+      this.logger.info("Executing lighthouse_create_dataset tool", {
+        name: args.name,
+        fileCount: (args.files as string[])?.length,
+      });
+
+      // Cast and validate parameters
+      const params: CreateDatasetParams = {
+        name: args.name as string,
+        description: args.description as string | undefined,
+        files: args.files as string[],
+        metadata: args.metadata as CreateDatasetParams["metadata"],
+        encrypt: args.encrypt as boolean | undefined,
+        accessConditions: args.accessConditions as AccessCondition[] | undefined,
+        tags: args.tags as string[] | undefined,
+        concurrency: args.concurrency as number | undefined,
+        timeout: args.timeout as number | undefined,
+        maxRetries: args.maxRetries as number | undefined,
+        continueOnError: args.continueOnError as boolean | undefined,
+      };
+
+      const validationError = await this.validateParams(params);
+      if (validationError) {
+        this.logger.warn("Parameter validation failed", { error: validationError });
+        return {
+          success: false,
+          error: `Invalid parameters: ${validationError}`,
+          executionTime: Date.now() - startTime,
+        };
+      }
+
+      // Prepare dataset configuration
+      const config: DatasetConfig = {
+        name: params.name,
+        description: params.description,
+        encrypt: params.encrypt,
+        accessConditions: params.accessConditions,
+        tags: params.tags,
+        metadata: params.metadata,
+      };
+
+      // Prepare create options
+      const options: DatasetCreateOptions = {
+        concurrency: params.concurrency,
+        timeout: params.timeout,
+        maxRetries: params.maxRetries,
+        continueOnError: params.continueOnError !== false, // default true
+      };
+
+      this.logger.info("Creating dataset", {
+        name: config.name,
+        fileCount: params.files.length,
+        encrypted: config.encrypt,
+        concurrency: options.concurrency,
+      });
+
+      // Create dataset
+      const dataset = await this.service.createDataset(config, params.files, options);
+
+      const executionTime = Date.now() - startTime;
+
+      this.logger.info("Dataset created successfully", {
+        datasetId: dataset.id,
+        name: dataset.name,
+        fileCount: dataset.files.length,
+        version: dataset.version,
+        executionTime,
+        executionTimeMinutes: (executionTime / 1000 / 60).toFixed(2),
+      });
+
+      // Format response
+      const responseData = {
+        success: true,
+        dataset: {
+          id: dataset.id,
+          name: dataset.name,
+          description: dataset.description,
+          fileCount: dataset.files.length,
+          totalSize: dataset.files.reduce((sum, f) => sum + f.size, 0),
+          version: dataset.version,
+          encrypted: dataset.encrypted,
+          createdAt: dataset.createdAt.toISOString(),
+          files: dataset.files.map((f) => ({
+            cid: f.cid,
+            size: f.size,
+            originalPath: f.originalPath,
+            encrypted: f.encrypted,
+          })),
+        },
+        executionTimeMs: executionTime,
+        executionTimeMinutes: (executionTime / 1000 / 60).toFixed(2),
+        performance: {
+          filesPerSecond: (dataset.files.length / (executionTime / 1000)).toFixed(2),
+          averageFileSizeMB:
+            dataset.files.length > 0
+              ? (
+                  dataset.files.reduce((sum, f) => sum + f.size, 0) /
+                  dataset.files.length /
+                  1024 /
+                  1024
+                ).toFixed(2)
+              : "0",
+        },
+      };
+
+      return {
+        success: true,
+        data: responseData,
+        executionTime,
+        metadata: {
+          datasetId: dataset.id,
+          fileCount: dataset.files.length,
+          version: dataset.version,
+        },
+      };
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+
+      this.logger.error("Dataset creation failed", error as Error, {
+        name: args.name as string,
+        fileCount: (args.files as string[])?.length,
+        executionTime,
+      });
+
+      return {
+        success: false,
+        error: `Dataset creation failed: ${errorMessage}`,
+        executionTime,
+        metadata: {
+          executionTime,
+        },
+      };
+    }
+  }
+}

--- a/apps/mcp-server/src/tools/LighthouseDatasetVersionTool.ts
+++ b/apps/mcp-server/src/tools/LighthouseDatasetVersionTool.ts
@@ -1,0 +1,283 @@
+/**
+ * Lighthouse Dataset Version Tool
+ * MCP tool for dataset version management (list, compare, rollback)
+ */
+
+import { Logger } from "@lighthouse-tooling/shared";
+import { MCPToolDefinition, ExecutionTimeCategory } from "@lighthouse-tooling/types";
+import { IDatasetService } from "../services/IDatasetService.js";
+import { ProgressAwareToolResult } from "./types.js";
+
+interface VersionToolParams {
+  operation: "list" | "compare" | "rollback" | "stats";
+  datasetId: string;
+  version?: string;
+  fromVersion?: string;
+  toVersion?: string;
+}
+
+export class LighthouseDatasetVersionTool {
+  private service: IDatasetService;
+  private logger: Logger;
+
+  constructor(service: IDatasetService, logger?: Logger) {
+    this.service = service;
+    this.logger =
+      logger || Logger.getInstance({ level: "info", component: "LighthouseDatasetVersionTool" });
+  }
+
+  static getDefinition(): MCPToolDefinition {
+    return {
+      name: "lighthouse_dataset_version",
+      description:
+        "Manage dataset versions: list all versions, compare versions, rollback to previous version, or get version statistics. Supports semantic versioning with change tracking.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          operation: {
+            type: "string",
+            description: "Operation to perform",
+            enum: ["list", "compare", "rollback", "stats"],
+          },
+          datasetId: {
+            type: "string",
+            description: "Unique identifier of the dataset",
+            minLength: 1,
+          },
+          version: {
+            type: "string",
+            description:
+              'Target version for rollback operation (e.g., "1.0.0"). Required for rollback.',
+          },
+          fromVersion: {
+            type: "string",
+            description: 'Starting version for comparison (e.g., "1.0.0"). Required for compare.',
+          },
+          toVersion: {
+            type: "string",
+            description: 'Ending version for comparison (e.g., "2.0.0"). Required for compare.',
+          },
+        },
+        required: ["operation", "datasetId"],
+        additionalProperties: false,
+      },
+      requiresAuth: true,
+      supportsBatch: false,
+      executionTime: ExecutionTimeCategory.FAST,
+    };
+  }
+
+  async execute(args: Record<string, unknown>): Promise<ProgressAwareToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const params: VersionToolParams = {
+        operation: args.operation as VersionToolParams["operation"],
+        datasetId: args.datasetId as string,
+        version: args.version as string | undefined,
+        fromVersion: args.fromVersion as string | undefined,
+        toVersion: args.toVersion as string | undefined,
+      };
+
+      // Validate required params
+      if (!params.operation) {
+        return {
+          success: false,
+          error: "operation is required",
+          executionTime: Date.now() - startTime,
+        };
+      }
+
+      if (!params.datasetId) {
+        return {
+          success: false,
+          error: "datasetId is required",
+          executionTime: Date.now() - startTime,
+        };
+      }
+
+      // Route to appropriate operation
+      switch (params.operation) {
+        case "list":
+          return await this.listVersions(params, startTime);
+        case "compare":
+          return await this.compareVersions(params, startTime);
+        case "rollback":
+          return await this.rollbackVersion(params, startTime);
+        case "stats":
+          return await this.getVersionStats(params, startTime);
+        default:
+          return {
+            success: false,
+            error: `Unknown operation: ${params.operation}`,
+            executionTime: Date.now() - startTime,
+          };
+      }
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+      this.logger.error("Version operation failed", error as Error, { args });
+      return {
+        success: false,
+        error: (error as Error).message,
+        executionTime,
+      };
+    }
+  }
+
+  private async listVersions(
+    params: VersionToolParams,
+    startTime: number,
+  ): Promise<ProgressAwareToolResult> {
+    const versions = await this.service.listVersions(params.datasetId);
+    const executionTime = Date.now() - startTime;
+
+    return {
+      success: true,
+      data: {
+        datasetId: params.datasetId,
+        versionCount: versions.length,
+        versions: versions.map((v) => ({
+          id: v.id,
+          version: v.version,
+          createdAt: v.createdAt.toISOString(),
+          createdBy: v.createdBy,
+          changeDescription: v.changeDescription,
+          changes: {
+            filesAdded: v.changes.filesAdded.length,
+            filesRemoved: v.changes.filesRemoved.length,
+            filesModified: v.changes.filesModified.length,
+            metadataChanged: v.changes.metadataChanged,
+            summary: v.changes.summary,
+          },
+          snapshot: {
+            fileCount: v.snapshot.fileCount,
+            totalSize: v.snapshot.totalSize,
+          },
+        })),
+      },
+      executionTime,
+    };
+  }
+
+  private async compareVersions(
+    params: VersionToolParams,
+    startTime: number,
+  ): Promise<ProgressAwareToolResult> {
+    if (!params.fromVersion || !params.toVersion) {
+      return {
+        success: false,
+        error: "fromVersion and toVersion are required for compare operation",
+        executionTime: Date.now() - startTime,
+      };
+    }
+
+    const diff = await this.service.compareVersions(
+      params.datasetId,
+      params.fromVersion,
+      params.toVersion,
+    );
+    const executionTime = Date.now() - startTime;
+
+    return {
+      success: true,
+      data: {
+        datasetId: params.datasetId,
+        fromVersion: diff.fromVersion,
+        toVersion: diff.toVersion,
+        summary: diff.summary,
+        filesAdded: diff.filesAdded.length,
+        filesRemoved: diff.filesRemoved.length,
+        filesModified: diff.filesModified.length,
+        metadataChanges: Object.keys(diff.metadataChanges).length,
+        details: {
+          addedFiles: diff.filesAdded.map((f) => ({
+            cid: f.cid,
+            size: f.size,
+            originalPath: f.originalPath,
+          })),
+          removedFiles: diff.filesRemoved.map((f) => ({
+            cid: f.cid,
+            size: f.size,
+            originalPath: f.originalPath,
+          })),
+          modifiedFiles: diff.filesModified.map((f) => ({
+            cid: f.cid,
+            size: f.size,
+            originalPath: f.originalPath,
+          })),
+          metadataChanges: diff.metadataChanges,
+        },
+      },
+      executionTime,
+    };
+  }
+
+  private async rollbackVersion(
+    params: VersionToolParams,
+    startTime: number,
+  ): Promise<ProgressAwareToolResult> {
+    if (!params.version) {
+      return {
+        success: false,
+        error: "version is required for rollback operation",
+        executionTime: Date.now() - startTime,
+      };
+    }
+
+    const dataset = await this.service.rollbackToVersion(params.datasetId, params.version);
+    const executionTime = Date.now() - startTime;
+
+    return {
+      success: true,
+      data: {
+        datasetId: dataset.id,
+        name: dataset.name,
+        rolledBackTo: params.version,
+        currentVersion: dataset.version,
+        fileCount: dataset.files.length,
+        totalSize: dataset.files.reduce((sum, f) => sum + f.size, 0),
+        updatedAt: dataset.updatedAt.toISOString(),
+        message: `Successfully rolled back to version ${params.version}. Current version is now ${dataset.version}`,
+      },
+      executionTime,
+      metadata: {
+        rolledBackTo: params.version,
+        newVersion: dataset.version,
+      },
+    };
+  }
+
+  private async getVersionStats(
+    params: VersionToolParams,
+    startTime: number,
+  ): Promise<ProgressAwareToolResult> {
+    const stats = await this.service.getDatasetStats(params.datasetId);
+    const versions = await this.service.listVersions(params.datasetId);
+    const executionTime = Date.now() - startTime;
+
+    return {
+      success: true,
+      data: {
+        datasetId: params.datasetId,
+        name: stats.name,
+        currentVersion: stats.version,
+        versionCount: stats.versionCount,
+        versions: versions.map((v) => ({
+          version: v.version,
+          createdAt: v.createdAt.toISOString(),
+          fileCount: v.snapshot.fileCount,
+          totalSize: v.snapshot.totalSize,
+          changes: v.changes.summary,
+        })),
+        stats: {
+          fileCount: stats.fileCount,
+          totalSize: stats.totalSize,
+          averageFileSize: stats.averageFileSize,
+          largestFileSize: stats.largestFileSize,
+          smallestFileSize: stats.smallestFileSize,
+        },
+      },
+      executionTime,
+    };
+  }
+}

--- a/apps/mcp-server/src/tools/LighthouseGetDatasetTool.ts
+++ b/apps/mcp-server/src/tools/LighthouseGetDatasetTool.ts
@@ -1,0 +1,106 @@
+/**
+ * Lighthouse Get Dataset Tool
+ * MCP tool for retrieving dataset information
+ */
+
+import { Logger } from "@lighthouse-tooling/shared";
+import { MCPToolDefinition, ExecutionTimeCategory } from "@lighthouse-tooling/types";
+import { IDatasetService } from "../services/IDatasetService.js";
+import { ProgressAwareToolResult } from "./types.js";
+
+interface GetDatasetParams {
+  datasetId: string;
+  version?: string;
+}
+
+export class LighthouseGetDatasetTool {
+  private service: IDatasetService;
+  private logger: Logger;
+
+  constructor(service: IDatasetService, logger?: Logger) {
+    this.service = service;
+    this.logger =
+      logger || Logger.getInstance({ level: "info", component: "LighthouseGetDatasetTool" });
+  }
+
+  static getDefinition(): MCPToolDefinition {
+    return {
+      name: "lighthouse_get_dataset",
+      description:
+        "Retrieve a dataset by ID, optionally at a specific version. Returns dataset metadata, files, and version information.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          datasetId: {
+            type: "string",
+            description: "Unique identifier of the dataset",
+            minLength: 1,
+          },
+          version: {
+            type: "string",
+            description: 'Optional version string (e.g., "1.0.0") to retrieve a specific version',
+          },
+        },
+        required: ["datasetId"],
+        additionalProperties: false,
+      },
+      requiresAuth: true,
+      supportsBatch: false,
+      executionTime: ExecutionTimeCategory.FAST,
+    };
+  }
+
+  async execute(args: Record<string, unknown>): Promise<ProgressAwareToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const params: GetDatasetParams = {
+        datasetId: args.datasetId as string,
+        version: args.version as string | undefined,
+      };
+
+      if (!params.datasetId) {
+        return {
+          success: false,
+          error: "datasetId is required",
+          executionTime: Date.now() - startTime,
+        };
+      }
+
+      const dataset = await this.service.getDataset(params.datasetId, params.version);
+      const executionTime = Date.now() - startTime;
+
+      return {
+        success: true,
+        data: {
+          id: dataset.id,
+          name: dataset.name,
+          description: dataset.description,
+          version: dataset.version,
+          fileCount: dataset.files.length,
+          totalSize: dataset.files.reduce((sum, f) => sum + f.size, 0),
+          encrypted: dataset.encrypted,
+          metadata: dataset.metadata,
+          createdAt: dataset.createdAt.toISOString(),
+          updatedAt: dataset.updatedAt.toISOString(),
+          files: dataset.files.map((f) => ({
+            cid: f.cid,
+            size: f.size,
+            originalPath: f.originalPath,
+            encrypted: f.encrypted,
+            uploadedAt: f.uploadedAt.toISOString(),
+          })),
+        },
+        executionTime,
+      };
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+      this.logger.error("Failed to get dataset", error as Error, { args });
+      return {
+        success: false,
+        error: (error as Error).message,
+        executionTime,
+      };
+    }
+  }
+}

--- a/apps/mcp-server/src/tools/LighthouseListDatasetsTool.ts
+++ b/apps/mcp-server/src/tools/LighthouseListDatasetsTool.ts
@@ -1,0 +1,136 @@
+/**
+ * Lighthouse List Datasets Tool
+ * MCP tool for listing datasets with filtering and pagination
+ */
+
+import { Logger } from "@lighthouse-tooling/shared";
+import { MCPToolDefinition, ExecutionTimeCategory, DatasetFilter } from "@lighthouse-tooling/types";
+import { IDatasetService } from "../services/IDatasetService.js";
+import { ProgressAwareToolResult } from "./types.js";
+
+export class LighthouseListDatasetsTool {
+  private service: IDatasetService;
+  private logger: Logger;
+
+  constructor(service: IDatasetService, logger?: Logger) {
+    this.service = service;
+    this.logger =
+      logger || Logger.getInstance({ level: "info", component: "LighthouseListDatasetsTool" });
+  }
+
+  static getDefinition(): MCPToolDefinition {
+    return {
+      name: "lighthouse_list_datasets",
+      description:
+        "List all datasets with optional filtering by encryption, tags, author, category, date range, and file count. Supports pagination.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          encrypted: {
+            type: "boolean",
+            description: "Filter by encryption status",
+          },
+          namePattern: {
+            type: "string",
+            description: "Filter by name pattern (regex)",
+          },
+          tags: {
+            type: "array",
+            description: "Filter by tags (datasets must have at least one matching tag)",
+            items: { type: "string", description: "Tag" },
+          },
+          author: {
+            type: "string",
+            description: "Filter by author",
+          },
+          category: {
+            type: "string",
+            description: "Filter by category",
+          },
+          minFiles: {
+            type: "number",
+            description: "Minimum number of files",
+            minimum: 0,
+          },
+          maxFiles: {
+            type: "number",
+            description: "Maximum number of files",
+            minimum: 0,
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of results to return",
+            default: 100,
+            minimum: 1,
+            maximum: 1000,
+          },
+          offset: {
+            type: "number",
+            description: "Number of results to skip (for pagination)",
+            default: 0,
+            minimum: 0,
+          },
+        },
+        additionalProperties: false,
+      },
+      requiresAuth: true,
+      supportsBatch: false,
+      executionTime: ExecutionTimeCategory.FAST,
+    };
+  }
+
+  async execute(args: Record<string, unknown>): Promise<ProgressAwareToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const filter: DatasetFilter = {
+        encrypted: args.encrypted as boolean | undefined,
+        namePattern: args.namePattern as string | undefined,
+        tags: args.tags as string[] | undefined,
+        author: args.author as string | undefined,
+        category: args.category as string | undefined,
+        minFiles: args.minFiles as number | undefined,
+        maxFiles: args.maxFiles as number | undefined,
+        limit: (args.limit as number) || 100,
+        offset: (args.offset as number) || 0,
+      };
+
+      const datasets = await this.service.listDatasets(filter);
+      const executionTime = Date.now() - startTime;
+
+      return {
+        success: true,
+        data: {
+          datasets: datasets.map((d) => ({
+            id: d.id,
+            name: d.name,
+            description: d.description,
+            version: d.version,
+            fileCount: d.files.length,
+            totalSize: d.files.reduce((sum, f) => sum + f.size, 0),
+            encrypted: d.encrypted,
+            author: d.metadata.author,
+            category: d.metadata.category,
+            keywords: d.metadata.keywords,
+            createdAt: d.createdAt.toISOString(),
+            updatedAt: d.updatedAt.toISOString(),
+          })),
+          count: datasets.length,
+          filter: {
+            limit: filter.limit,
+            offset: filter.offset,
+          },
+        },
+        executionTime,
+      };
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+      this.logger.error("Failed to list datasets", error as Error, { args });
+      return {
+        success: false,
+        error: (error as Error).message,
+        executionTime,
+      };
+    }
+  }
+}

--- a/apps/mcp-server/src/tools/LighthouseUpdateDatasetTool.ts
+++ b/apps/mcp-server/src/tools/LighthouseUpdateDatasetTool.ts
@@ -1,0 +1,138 @@
+/**
+ * Lighthouse Update Dataset Tool
+ * MCP tool for updating datasets with automatic versioning
+ */
+
+import { Logger } from "@lighthouse-tooling/shared";
+import { MCPToolDefinition, ExecutionTimeCategory, DatasetUpdate } from "@lighthouse-tooling/types";
+import { IDatasetService } from "../services/IDatasetService.js";
+import { ProgressAwareToolResult } from "./types.js";
+
+export class LighthouseUpdateDatasetTool {
+  private service: IDatasetService;
+  private logger: Logger;
+
+  constructor(service: IDatasetService, logger?: Logger) {
+    this.service = service;
+    this.logger =
+      logger || Logger.getInstance({ level: "info", component: "LighthouseUpdateDatasetTool" });
+  }
+
+  static getDefinition(): MCPToolDefinition {
+    return {
+      name: "lighthouse_update_dataset",
+      description:
+        "Update a dataset's metadata, description, or files. Automatically creates a new version. Supports adding/removing files and tags.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          datasetId: {
+            type: "string",
+            description: "Unique identifier of the dataset to update",
+            minLength: 1,
+          },
+          description: {
+            type: "string",
+            description: "Updated description",
+          },
+          metadata: {
+            type: "object",
+            description: "Updated metadata fields",
+            properties: {
+              author: { type: "string", description: "Dataset author" },
+              license: { type: "string", description: "Dataset license" },
+              category: { type: "string", description: "Dataset category" },
+              keywords: {
+                type: "array",
+                description: "Dataset keywords",
+                items: { type: "string", description: "Keyword" },
+              },
+              custom: { type: "object", description: "Custom metadata" },
+            },
+          },
+          addFiles: {
+            type: "array",
+            description: "Array of file paths to add to the dataset",
+            items: { type: "string", description: "File path" },
+          },
+          removeFiles: {
+            type: "array",
+            description: "Array of CIDs to remove from the dataset",
+            items: { type: "string", description: "File CID" },
+          },
+          addTags: {
+            type: "array",
+            description: "Tags to add to the dataset",
+            items: { type: "string", description: "Tag" },
+          },
+          removeTags: {
+            type: "array",
+            description: "Tags to remove from the dataset",
+            items: { type: "string", description: "Tag" },
+          },
+        },
+        required: ["datasetId"],
+        additionalProperties: false,
+      },
+      requiresAuth: true,
+      supportsBatch: false,
+      executionTime: ExecutionTimeCategory.MEDIUM,
+    };
+  }
+
+  async execute(args: Record<string, unknown>): Promise<ProgressAwareToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const datasetId = args.datasetId as string;
+      if (!datasetId) {
+        return {
+          success: false,
+          error: "datasetId is required",
+          executionTime: Date.now() - startTime,
+        };
+      }
+
+      const updates: DatasetUpdate = {
+        description: args.description as string | undefined,
+        metadata: args.metadata as DatasetUpdate["metadata"],
+        addFiles: args.addFiles as string[] | undefined,
+        removeFiles: args.removeFiles as string[] | undefined,
+        addTags: args.addTags as string[] | undefined,
+        removeTags: args.removeTags as string[] | undefined,
+      };
+
+      const dataset = await this.service.updateDataset(datasetId, updates);
+      const executionTime = Date.now() - startTime;
+
+      return {
+        success: true,
+        data: {
+          id: dataset.id,
+          name: dataset.name,
+          description: dataset.description,
+          version: dataset.version,
+          fileCount: dataset.files.length,
+          totalSize: dataset.files.reduce((sum, f) => sum + f.size, 0),
+          encrypted: dataset.encrypted,
+          metadata: dataset.metadata,
+          updatedAt: dataset.updatedAt.toISOString(),
+        },
+        executionTime,
+        metadata: {
+          newVersion: dataset.version,
+          filesAdded: updates.addFiles?.length || 0,
+          filesRemoved: updates.removeFiles?.length || 0,
+        },
+      };
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+      this.logger.error("Failed to update dataset", error as Error, { args });
+      return {
+        success: false,
+        error: (error as Error).message,
+        executionTime,
+      };
+    }
+  }
+}

--- a/apps/mcp-server/src/tools/index.ts
+++ b/apps/mcp-server/src/tools/index.ts
@@ -4,17 +4,35 @@
 
 export { LighthouseUploadFileTool } from "./LighthouseUploadFileTool.js";
 export { LighthouseFetchFileTool } from "./LighthouseFetchFileTool.js";
+export { LighthouseCreateDatasetTool } from "./LighthouseCreateDatasetTool.js";
+export { LighthouseGetDatasetTool } from "./LighthouseGetDatasetTool.js";
+export { LighthouseListDatasetsTool } from "./LighthouseListDatasetsTool.js";
+export { LighthouseUpdateDatasetTool } from "./LighthouseUpdateDatasetTool.js";
+export { LighthouseDatasetVersionTool } from "./LighthouseDatasetVersionTool.js";
 export * from "./types.js";
 
 import { LighthouseUploadFileTool } from "./LighthouseUploadFileTool.js";
 import { LighthouseFetchFileTool } from "./LighthouseFetchFileTool.js";
+import { LighthouseCreateDatasetTool } from "./LighthouseCreateDatasetTool.js";
+import { LighthouseGetDatasetTool } from "./LighthouseGetDatasetTool.js";
+import { LighthouseListDatasetsTool } from "./LighthouseListDatasetsTool.js";
+import { LighthouseUpdateDatasetTool } from "./LighthouseUpdateDatasetTool.js";
+import { LighthouseDatasetVersionTool } from "./LighthouseDatasetVersionTool.js";
 import { MCPToolDefinition } from "@lighthouse-tooling/types";
 
 /**
  * Get all available tool definitions
  */
 export function getAllToolDefinitions(): MCPToolDefinition[] {
-  return [LighthouseUploadFileTool.getDefinition(), LighthouseFetchFileTool.getDefinition()];
+  return [
+    LighthouseUploadFileTool.getDefinition(),
+    LighthouseFetchFileTool.getDefinition(),
+    LighthouseCreateDatasetTool.getDefinition(),
+    LighthouseGetDatasetTool.getDefinition(),
+    LighthouseListDatasetsTool.getDefinition(),
+    LighthouseUpdateDatasetTool.getDefinition(),
+    LighthouseDatasetVersionTool.getDefinition(),
+  ];
 }
 
 /**
@@ -23,4 +41,9 @@ export function getAllToolDefinitions(): MCPToolDefinition[] {
 export const ToolFactory = {
   LighthouseUploadFileTool,
   LighthouseFetchFileTool,
+  LighthouseCreateDatasetTool,
+  LighthouseGetDatasetTool,
+  LighthouseListDatasetsTool,
+  LighthouseUpdateDatasetTool,
+  LighthouseDatasetVersionTool,
 } as const;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/packages/types/src/core.ts
+++ b/packages/types/src/core.ts
@@ -190,3 +190,223 @@ export interface DownloadResult {
   /** Hash of the downloaded file for integrity verification */
   hash?: string;
 }
+
+/**
+ * Result of a batch upload operation
+ */
+export interface BatchUploadResult {
+  /** Total number of files attempted */
+  total: number;
+  /** Number of successful uploads */
+  successful: number;
+  /** Number of failed uploads */
+  failed: number;
+  /** Array of successful upload results */
+  successfulUploads: UploadResult[];
+  /** Array of failed upload attempts */
+  failedUploads: FailedUpload[];
+  /** Total time taken for the batch operation */
+  duration: number;
+  /** Average upload speed in bytes per second */
+  averageSpeed?: number;
+}
+
+/**
+ * Information about a failed upload
+ */
+export interface FailedUpload {
+  /** File path that failed to upload */
+  filePath: string;
+  /** Error message describing the failure */
+  error: string;
+  /** Number of retry attempts made */
+  retryAttempts: number;
+  /** Timestamp when the failure occurred */
+  failedAt: Date;
+}
+
+/**
+ * Dataset version information
+ */
+export interface DatasetVersion {
+  /** Unique version identifier */
+  id: string;
+  /** Parent dataset ID */
+  datasetId: string;
+  /** Semantic version string (e.g., "1.0.0", "2.1.3") */
+  version: string;
+  /** Changes made in this version */
+  changes: VersionChanges;
+  /** Full snapshot of dataset state at this version */
+  snapshot: DatasetSnapshot;
+  /** Timestamp when version was created */
+  createdAt: Date;
+  /** User or system that created this version */
+  createdBy?: string;
+  /** Optional description of changes */
+  changeDescription?: string;
+  /** Tags associated with this version */
+  tags?: string[];
+}
+
+/**
+ * Changes made in a dataset version
+ */
+export interface VersionChanges {
+  /** CIDs of files added in this version */
+  filesAdded: string[];
+  /** CIDs of files removed in this version */
+  filesRemoved: string[];
+  /** CIDs of files modified in this version */
+  filesModified: string[];
+  /** Whether metadata was changed */
+  metadataChanged: boolean;
+  /** Whether configuration was changed */
+  configChanged: boolean;
+  /** Summary of changes */
+  summary: string;
+}
+
+/**
+ * Snapshot of dataset state at a specific version
+ */
+export interface DatasetSnapshot {
+  /** All files in the dataset at this version */
+  files: UploadResult[];
+  /** Metadata at this version */
+  metadata: DatasetMetadata;
+  /** Configuration at this version */
+  config: Partial<DatasetConfig>;
+  /** Size of dataset in bytes */
+  totalSize: number;
+  /** Number of files */
+  fileCount: number;
+}
+
+/**
+ * Update parameters for modifying an existing dataset
+ */
+export interface DatasetUpdate {
+  /** New description for the dataset */
+  description?: string;
+  /** Updated metadata */
+  metadata?: Partial<DatasetMetadata>;
+  /** New version string (if manually specified) */
+  version?: string;
+  /** Files to add to the dataset */
+  addFiles?: string[];
+  /** CIDs of files to remove from the dataset */
+  removeFiles?: string[];
+  /** Tags to add */
+  addTags?: string[];
+  /** Tags to remove */
+  removeTags?: string[];
+}
+
+/**
+ * Filter criteria for listing datasets
+ */
+export interface DatasetFilter {
+  /** Filter by encryption status */
+  encrypted?: boolean;
+  /** Filter by name pattern (regex) */
+  namePattern?: string;
+  /** Filter by tags (datasets must have at least one) */
+  tags?: string[];
+  /** Filter by author */
+  author?: string;
+  /** Filter by category */
+  category?: string;
+  /** Filter by creation date (after) */
+  createdAfter?: Date;
+  /** Filter by creation date (before) */
+  createdBefore?: Date;
+  /** Filter by minimum number of files */
+  minFiles?: number;
+  /** Filter by maximum number of files */
+  maxFiles?: number;
+  /** Pagination limit */
+  limit?: number;
+  /** Pagination offset */
+  offset?: number;
+}
+
+/**
+ * Statistics for a dataset
+ */
+export interface DatasetStats {
+  /** Dataset ID */
+  id: string;
+  /** Dataset name */
+  name: string;
+  /** Total number of files */
+  fileCount: number;
+  /** Total size in bytes */
+  totalSize: number;
+  /** Whether dataset is encrypted */
+  encrypted: boolean;
+  /** Current version */
+  version: string;
+  /** Number of versions */
+  versionCount: number;
+  /** Creation timestamp */
+  createdAt: Date;
+  /** Last update timestamp */
+  updatedAt: Date;
+  /** Last accessed timestamp */
+  lastAccessedAt?: Date;
+  /** Average file size */
+  averageFileSize: number;
+  /** Largest file size */
+  largestFileSize: number;
+  /** Smallest file size */
+  smallestFileSize: number;
+}
+
+/**
+ * Comparison result between two dataset versions
+ */
+export interface VersionDiff {
+  /** Source version */
+  fromVersion: string;
+  /** Target version */
+  toVersion: string;
+  /** Files added between versions */
+  filesAdded: UploadResult[];
+  /** Files removed between versions */
+  filesRemoved: UploadResult[];
+  /** Files that exist in both but were modified */
+  filesModified: UploadResult[];
+  /** Metadata differences */
+  metadataChanges: Record<string, { from: unknown; to: unknown }>;
+  /** Summary of differences */
+  summary: string;
+}
+
+/**
+ * Progress information for batch operations
+ */
+export interface BatchProgress {
+  /** Operation ID for tracking */
+  operationId: string;
+  /** Type of batch operation */
+  operation: "upload" | "download" | "delete";
+  /** Total items to process */
+  total: number;
+  /** Items completed successfully */
+  completed: number;
+  /** Items that failed */
+  failed: number;
+  /** Current item being processed */
+  currentItem?: string;
+  /** Progress percentage (0-100) */
+  percentage: number;
+  /** Estimated time remaining in milliseconds */
+  estimatedTimeRemaining?: number;
+  /** Current processing rate (items per second) */
+  rate?: number;
+  /** Start time */
+  startedAt: Date;
+  /** List of failed items */
+  failures: FailedUpload[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,16 @@ export type {
   UploadConfig,
   DatasetConfig,
   DownloadResult,
+  BatchUploadResult,
+  FailedUpload,
+  DatasetVersion,
+  VersionChanges,
+  DatasetSnapshot,
+  DatasetUpdate,
+  DatasetFilter,
+  DatasetStats,
+  VersionDiff,
+  BatchProgress,
 } from "./core.js";
 
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       "@modelcontextprotocol/sdk":
         specifier: ^1.0.4
         version: 1.18.1
+      eventemitter3:
+        specifier: ^5.0.1
+        version: 5.0.1
     devDependencies:
       "@vitest/coverage-v8":
         specifier: ^1.0.0


### PR DESCRIPTION
# Pull Request

## Description
Fixes https://github.com/Patrick-Ehimen/lighthouse-agent-tooling/issues/26
A complete dataset management system for AI agents to create, version, and manage file collections with metadata and parallel processing capabilities.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- List any related issues, e.g. Fixes #123 -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Summary by Sourcery

Introduce a comprehensive dataset management system with full versioning and high-performance parallel uploads, integrated into the MCP server via new services and tools.

New Features:
- Define IDatasetService and implement DatasetService for creating, retrieving, updating, deleting, and stat’ing datasets
- Implement DatasetVersionManager for semantic versioning, history, rollback, and diff between dataset versions
- Implement BatchUploadManager for parallel and batched file uploads with progress tracking and retry handling
- Add MCP tools for dataset operations: lighthouse_create_dataset, lighthouse_get_dataset, lighthouse_list_datasets, lighthouse_update_dataset, and lighthouse_dataset_version

Enhancements:
- Replace MockDatasetService with the new DatasetService in the MCP server and related handlers
- Extend core type definitions with dataset interfaces (versions, snapshots, stats, batch results, progress)
- Update the server registry and ListResources handler to register and invoke the new dataset tools asynchronously

Build:
- Add a build script to the types package

Tests:
- Scaffold test files for BatchUploadManager, DatasetService, DatasetVersionManager, and new MCP tools