### PR TITLE
Replace mock ExtensionCore with real implementation

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -158,6 +158,7 @@
     "@lighthouse-tooling/sdk-wrapper": "workspace:*",
     "@lighthouse-tooling/shared": "workspace:*",
     "@lighthouse-tooling/types": "workspace:*",
+    "@lighthouse-tooling/extension-core": "workspace:*",
     "fs-extra": "^11.3.2"
   },
   "devDependencies": {

--- a/packages/vscode-extension/src/core/mock-extension-core.ts
+++ b/packages/vscode-extension/src/core/mock-extension-core.ts
@@ -1,6 +1,9 @@
 /**
  * Mock Extension Core
- * @fileoverview Temporary mock implementation until extension-core is available
+ * @fileoverview DEPRECATED: This mock implementation has been replaced by the real
+ * ExtensionCore from @lighthouse-tooling/extension-core package.
+ * This file is kept for reference but is no longer used.
+ * @deprecated Use @lighthouse-tooling/extension-core instead
  */
 
 import type { LighthouseAISDK } from "@lighthouse-tooling/sdk-wrapper";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
 
   packages/vscode-extension:
     dependencies:
+      "@lighthouse-tooling/extension-core":
+        specifier: workspace:*
+        version: link:../extension-core
       "@lighthouse-tooling/sdk-wrapper":
         specifier: workspace:*
         version: link:../sdk-wrapper


### PR DESCRIPTION
# Pull Request

## Description

<!-- Please include a summary of the change and which issue is fixed. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- List any related issues, e.g. Fixes #123 -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Summary by Sourcery

Replace the mock extension core with the real implementation by using createExtensionCore, enable AI command handling, update the extension activation order to initialize the SDK, configure the API key, initialize the core, and then set up VSCode UI components, and add the core package as a dependency.

Enhancements:
- Replace mock ExtensionCore with real createExtensionCore implementation
- Update activation sequence to initialize the SDK, set LIGHTHOUSE_API_KEY, initialize the extension core, then UI components
- Remove mock-extension-core.ts and related pnpm-lock updates

Build:
- Add @lighthouse-tooling/extension-core to package.json