### PR TITLE
mcp mac bug fix

### DIFF
--- a/apps/mcp-server/src/config/server-config.ts
+++ b/apps/mcp-server/src/config/server-config.ts
@@ -93,7 +93,7 @@ export const DEFAULT_SERVER_CONFIG: ServerConfig = {
   version: "0.1.0",
   logLevel: "info",
   maxStorageSize: 1024 * 1024 * 1024, // 1GB
-  enableMetrics: true,
+  enableMetrics: false, // Disabled by default to avoid interfering with MCP stdio protocol
   metricsInterval: 60000, // 1 minute
   lighthouseApiKey: process.env.LIGHTHOUSE_API_KEY,
   authentication: DEFAULT_AUTH_CONFIG,

--- a/apps/mcp-server/test-operations.js
+++ b/apps/mcp-server/test-operations.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Test script for verifying MCP server operations
+ * Tests:
+ * 1. List Lighthouse datasets
+ * 2. Upload README.md to Lighthouse
+ * 3. Get details for dataset dataset_5
+ */
+
+import { LighthouseMCPServer } from "./dist/server.js";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join, resolve } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const workspaceRoot = resolve(__dirname, "../..");
+
+async function testOperations() {
+  console.log("🧪 Testing MCP Server Operations\n");
+
+  // Get API key from environment
+  const apiKey = process.env.LIGHTHOUSE_API_KEY;
+  if (!apiKey) {
+    console.error("❌ Error: LIGHTHOUSE_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  console.log(
+    `🔑 Using API key: ${apiKey.substring(0, 10)}...${apiKey.substring(apiKey.length - 4)}\n`,
+  );
+
+  // Initialize server
+  let server;
+  try {
+    console.log("📦 Initializing MCP server...");
+    server = new LighthouseMCPServer({
+      lighthouseApiKey: apiKey,
+      logLevel: "info",
+    });
+
+    await server.registerTools();
+    console.log("✅ Server initialized\n");
+  } catch (error) {
+    console.error("❌ Failed to initialize server:", error.message);
+    process.exit(1);
+  }
+
+  const registry = server.getRegistry();
+
+  // Test 1: "List my Lighthouse datasets"
+  console.log('📋 Command: "List my Lighthouse datasets"');
+  try {
+    const listResult = await registry.executeTool("lighthouse_list_datasets", {
+      limit: 10,
+      offset: 0,
+    });
+
+    if (listResult.success) {
+      const data = listResult.data;
+      console.log("✅ Successfully listed datasets");
+      console.log(`   Found ${data.total || 0} dataset(s)`);
+      if (data.datasets && data.datasets.length > 0) {
+        console.log("   Datasets:");
+        data.datasets.forEach((ds, idx) => {
+          console.log(`   ${idx + 1}. ${ds.name} (ID: ${ds.id})`);
+        });
+      } else {
+        console.log("   No datasets found");
+      }
+    } else {
+      console.log(`❌ Failed: ${listResult.error}`);
+    }
+  } catch (error) {
+    console.log(`❌ Error: ${error.message}`);
+  }
+  console.log();
+
+  // Test 2: "Upload README.md to Lighthouse"
+  console.log('📤 Command: "Upload README.md to Lighthouse"');
+  try {
+    const readmePath = join(workspaceRoot, "README.md");
+    const readmeExists = readFileSync(readmePath, { encoding: "utf8" });
+
+    const uploadResult = await registry.executeTool("lighthouse_upload_file", {
+      filePath: readmePath,
+      encrypt: false,
+    });
+
+    if (uploadResult.success) {
+      const data = uploadResult.data;
+      console.log("✅ Successfully uploaded README.md");
+      console.log(`   CID: ${data.cid}`);
+      console.log(`   Size: ${data.size} bytes`);
+      console.log(`   Encrypted: ${data.encrypted}`);
+    } else {
+      console.log(`❌ Failed: ${uploadResult.error}`);
+    }
+  } catch (error) {
+    console.log(`❌ Error: ${error.message}`);
+  }
+  console.log();
+
+  // Test 3: "Get details for dataset dataset_5"
+  console.log('🔍 Command: "Get details for dataset dataset_5"');
+  try {
+    const getResult = await registry.executeTool("lighthouse_get_dataset", {
+      datasetId: "dataset_5",
+    });
+
+    if (getResult.success) {
+      const data = getResult.data;
+      console.log("✅ Successfully retrieved dataset details");
+      console.log(`   ID: ${data.dataset.id}`);
+      console.log(`   Name: ${data.dataset.name}`);
+      console.log(`   Description: ${data.dataset.description || "N/A"}`);
+      console.log(`   Files: ${data.dataset.files?.length || 0}`);
+      console.log(`   Version: ${data.dataset.version}`);
+    } else {
+      console.log(`❌ Failed: ${getResult.error}`);
+      if (getResult.error.includes("not found")) {
+        console.log("   (This is expected if dataset_5 doesn't exist)");
+      }
+    }
+  } catch (error) {
+    console.log(`❌ Error: ${error.message}`);
+  }
+  console.log();
+
+  // Cleanup
+  try {
+    await server.stop();
+    console.log("✅ Server stopped");
+  } catch (error) {
+    console.log(`⚠️  Warning: Error stopping server: ${error.message}`);
+  }
+
+  console.log("\n✨ Testing complete!");
+}
+
+// Run tests
+testOperations().catch((error) => {
+  console.error("❌ Fatal error:", error);
+  process.exit(1);
+});

--- a/packages/shared/src/utils/logger.ts
+++ b/packages/shared/src/utils/logger.ts
@@ -197,15 +197,16 @@ export class Logger {
 
     const logMessage = `${prefix} ${message}${contextStr}`;
 
+    // For MCP stdio transport, all logs should go to stderr to avoid interfering with JSON-RPC on stdout
     switch (level) {
       case "debug":
-        console.debug(logMessage);
+        console.error(logMessage); // Redirect to stderr
         break;
       case "info":
-        console.info(logMessage);
+        console.error(logMessage); // Redirect to stderr
         break;
       case "warn":
-        console.warn(logMessage);
+        console.error(logMessage); // Already stderr, but be explicit
         break;
       case "error":
       case "fatal":


### PR DESCRIPTION
# Pull Request

## Description

<!-- Please include a summary of the change and which issue is fixed. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- List any related issues, e.g. Fixes #123 -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Summary by Sourcery

Improve Lighthouse MCP server robustness and compatibility with MCP stdio, and add a local test harness for core operations.

Bug Fixes:
- Fetch datasets from LighthouseService in ListResources with a fallback to the mock dataset service when the Lighthouse API fails.
- Make LighthouseService resilient when the SQLite-backed DatabaseService is unavailable and when the SDK listFiles API is not supported, falling back to in-memory cache and optional database usage.
- Prevent logging from interfering with MCP JSON-RPC by routing non-error log levels to stderr and disabling metrics by default.

Enhancements:
- Add a ReadResource handler to expose Lighthouse datasets and files as JSON resources with robust serialization and error handling.
- Guard all database interactions in LighthouseService so they are optional and do not crash when the database is missing or failing.

Tests:
- Add a test-operations CLI script to manually exercise core MCP server operations like listing datasets, uploading a file, and fetching dataset details.