### PR TITLE
Add Prometheus metrics export endpoint for monitoring integration

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -21,7 +21,8 @@
     "@lighthouse-tooling/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "better-sqlite3": "^11.7.0",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "prom-client": "^15.1.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",

--- a/apps/mcp-server/src/auth/MetricsCollector.ts
+++ b/apps/mcp-server/src/auth/MetricsCollector.ts
@@ -216,6 +216,16 @@ export class MetricsCollector {
   }
 
   /**
+   * Get raw cache counters for Prometheus export
+   */
+  getCacheCounters(): { hits: number; misses: number } {
+    return {
+      hits: this.cacheHits,
+      misses: this.cacheMisses,
+    };
+  }
+
+  /**
    * Get security events within time range
    */
   getSecurityEvents(since?: Date): SecurityEvent[] {

--- a/apps/mcp-server/src/config/server-config.ts
+++ b/apps/mcp-server/src/config/server-config.ts
@@ -96,6 +96,7 @@ export const DEFAULT_HEALTH_CHECK_CONFIG: HealthCheckConfig = {
   lighthouseApiUrl: process.env.LIGHTHOUSE_API_URL || "https://api.lighthouse.storage",
   connectivityCheckInterval: 30000,
   connectivityTimeout: 5000,
+  metricsEnabled: process.env.PROMETHEUS_METRICS_ENABLED !== "false", // Enabled by default
 };
 
 export const DEFAULT_ORGANIZATION_SETTINGS: OrganizationSettings = {

--- a/apps/mcp-server/src/health/PrometheusExporter.ts
+++ b/apps/mcp-server/src/health/PrometheusExporter.ts
@@ -1,0 +1,367 @@
+/**
+ * Prometheus Metrics Exporter
+ *
+ * Exports internal metrics in Prometheus text format for scraping
+ * by Prometheus, Grafana, Datadog, and other monitoring systems.
+ */
+
+import * as client from "prom-client";
+import { MetricsCollector, SecurityEventType } from "../auth/MetricsCollector.js";
+import { ToolRegistry } from "../registry/ToolRegistry.js";
+import { LighthouseServiceFactory } from "../auth/LighthouseServiceFactory.js";
+import { ILighthouseService } from "../services/ILighthouseService.js";
+
+export interface PrometheusExporterDependencies {
+  metricsCollector: MetricsCollector;
+  registry: ToolRegistry;
+  serviceFactory: LighthouseServiceFactory;
+  lighthouseService: ILighthouseService;
+}
+
+export class PrometheusExporter {
+  private deps: PrometheusExporterDependencies;
+  private registry: client.Registry;
+
+  // Counters (initialized in initializeMetrics called from constructor)
+  private authTotal!: client.Counter<"status">;
+  private cacheHitsTotal!: client.Counter<string>;
+  private cacheMissesTotal!: client.Counter<string>;
+  private securityEventsTotal!: client.Counter<"type">;
+  private toolCallsTotal!: client.Counter<"tool">;
+
+  // Gauges (initialized in initializeMetrics called from constructor)
+  private cacheSize!: client.Gauge<string>;
+  private cacheMaxSize!: client.Gauge<string>;
+  private servicePoolSize!: client.Gauge<string>;
+  private servicePoolMaxSize!: client.Gauge<string>;
+  private storageFiles!: client.Gauge<string>;
+  private storageBytes!: client.Gauge<string>;
+  private storageMaxBytes!: client.Gauge<string>;
+  private storageUtilization!: client.Gauge<string>;
+  private uniqueApiKeys!: client.Gauge<string>;
+  private toolsRegistered!: client.Gauge<string>;
+
+  // Histograms (initialized in initializeMetrics called from constructor)
+  private requestDuration!: client.Histogram<"operation">;
+  private authDuration!: client.Histogram<string>;
+
+  // Track last known values to compute deltas for counters
+  private lastCacheCounters = { hits: 0, misses: 0 };
+  private lastAuthMetrics = {
+    authenticatedRequests: 0,
+    failedAuthentications: 0,
+    fallbackRequests: 0,
+  };
+  private lastSecurityEventCounts: Map<string, number> = new Map();
+  private lastToolCallCounts: Map<string, number> = new Map();
+
+  constructor(deps: PrometheusExporterDependencies) {
+    this.deps = deps;
+
+    // Create a custom registry to avoid conflicts with default registry
+    this.registry = new client.Registry();
+
+    // Set default labels
+    this.registry.setDefaultLabels({
+      app: "lighthouse-mcp-server",
+    });
+
+    // Collect default Node.js process metrics
+    client.collectDefaultMetrics({
+      register: this.registry,
+      prefix: "lighthouse_",
+    });
+
+    // Initialize custom metrics
+    this.initializeMetrics();
+  }
+
+  private initializeMetrics(): void {
+    // Authentication counters
+    this.authTotal = new client.Counter({
+      name: "lighthouse_auth_total",
+      help: "Total authentication attempts",
+      labelNames: ["status"],
+      registers: [this.registry],
+    });
+
+    // Cache counters
+    this.cacheHitsTotal = new client.Counter({
+      name: "lighthouse_cache_hits_total",
+      help: "Total cache hits",
+      registers: [this.registry],
+    });
+
+    this.cacheMissesTotal = new client.Counter({
+      name: "lighthouse_cache_misses_total",
+      help: "Total cache misses",
+      registers: [this.registry],
+    });
+
+    // Security events counter
+    this.securityEventsTotal = new client.Counter({
+      name: "lighthouse_security_events_total",
+      help: "Total security events by type",
+      labelNames: ["type"],
+      registers: [this.registry],
+    });
+
+    // Tool calls counter
+    this.toolCallsTotal = new client.Counter({
+      name: "lighthouse_tool_calls_total",
+      help: "Total tool calls by tool name",
+      labelNames: ["tool"],
+      registers: [this.registry],
+    });
+
+    // Cache gauges
+    this.cacheSize = new client.Gauge({
+      name: "lighthouse_cache_size",
+      help: "Current cache size (number of entries)",
+      registers: [this.registry],
+    });
+
+    this.cacheMaxSize = new client.Gauge({
+      name: "lighthouse_cache_max_size",
+      help: "Maximum cache size",
+      registers: [this.registry],
+    });
+
+    // Service pool gauges
+    this.servicePoolSize = new client.Gauge({
+      name: "lighthouse_service_pool_size",
+      help: "Current service pool size",
+      registers: [this.registry],
+    });
+
+    this.servicePoolMaxSize = new client.Gauge({
+      name: "lighthouse_service_pool_max_size",
+      help: "Maximum service pool size",
+      registers: [this.registry],
+    });
+
+    // Storage gauges
+    this.storageFiles = new client.Gauge({
+      name: "lighthouse_storage_files",
+      help: "Number of files in storage",
+      registers: [this.registry],
+    });
+
+    this.storageBytes = new client.Gauge({
+      name: "lighthouse_storage_bytes",
+      help: "Total storage usage in bytes",
+      registers: [this.registry],
+    });
+
+    this.storageMaxBytes = new client.Gauge({
+      name: "lighthouse_storage_max_bytes",
+      help: "Maximum storage capacity in bytes",
+      registers: [this.registry],
+    });
+
+    this.storageUtilization = new client.Gauge({
+      name: "lighthouse_storage_utilization",
+      help: "Storage utilization ratio (0-1)",
+      registers: [this.registry],
+    });
+
+    // Unique API keys gauge
+    this.uniqueApiKeys = new client.Gauge({
+      name: "lighthouse_unique_api_keys",
+      help: "Number of unique API keys seen",
+      registers: [this.registry],
+    });
+
+    // Tools registered gauge
+    this.toolsRegistered = new client.Gauge({
+      name: "lighthouse_tools_registered",
+      help: "Number of tools registered",
+      registers: [this.registry],
+    });
+
+    // Request duration histogram
+    this.requestDuration = new client.Histogram({
+      name: "lighthouse_request_duration_seconds",
+      help: "Request duration in seconds",
+      labelNames: ["operation"],
+      buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+      registers: [this.registry],
+    });
+
+    // Authentication duration histogram
+    this.authDuration = new client.Histogram({
+      name: "lighthouse_auth_duration_seconds",
+      help: "Authentication duration in seconds",
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
+      registers: [this.registry],
+    });
+  }
+
+  /**
+   * Update all metrics from current state
+   */
+  private updateMetrics(): void {
+    this.updateAuthMetrics();
+    this.updateCacheMetrics();
+    this.updateSecurityMetrics();
+    this.updateToolMetrics();
+    this.updateServicePoolMetrics();
+    this.updateStorageMetrics();
+  }
+
+  private updateAuthMetrics(): void {
+    const metrics = this.deps.metricsCollector.getMetrics();
+
+    // Calculate deltas for counters (Prometheus counters only increment)
+    const successDelta = metrics.authenticatedRequests - this.lastAuthMetrics.authenticatedRequests;
+    const failureDelta = metrics.failedAuthentications - this.lastAuthMetrics.failedAuthentications;
+    const fallbackDelta = metrics.fallbackRequests - this.lastAuthMetrics.fallbackRequests;
+
+    if (successDelta > 0) {
+      this.authTotal.labels("success").inc(successDelta);
+    }
+    if (failureDelta > 0) {
+      this.authTotal.labels("failure").inc(failureDelta);
+    }
+    if (fallbackDelta > 0) {
+      this.authTotal.labels("fallback").inc(fallbackDelta);
+    }
+
+    // Update last known values
+    this.lastAuthMetrics = {
+      authenticatedRequests: metrics.authenticatedRequests,
+      failedAuthentications: metrics.failedAuthentications,
+      fallbackRequests: metrics.fallbackRequests,
+    };
+
+    // Update gauge for unique API keys
+    this.uniqueApiKeys.set(metrics.uniqueApiKeys);
+
+    // Record average auth time in histogram (approximation)
+    if (metrics.averageAuthTime > 0) {
+      this.authDuration.observe(metrics.averageAuthTime / 1000);
+    }
+  }
+
+  private updateCacheMetrics(): void {
+    const cacheCounters = this.deps.metricsCollector.getCacheCounters();
+
+    // Calculate deltas
+    const hitsDelta = cacheCounters.hits - this.lastCacheCounters.hits;
+    const missesDelta = cacheCounters.misses - this.lastCacheCounters.misses;
+
+    if (hitsDelta > 0) {
+      this.cacheHitsTotal.inc(hitsDelta);
+    }
+    if (missesDelta > 0) {
+      this.cacheMissesTotal.inc(missesDelta);
+    }
+
+    // Update last known values
+    this.lastCacheCounters = { ...cacheCounters };
+
+    // Note: Cache size/maxSize would need to come from AuthManager.getCacheStats()
+    // For now, we derive from the metrics collector's data
+  }
+
+  private updateSecurityMetrics(): void {
+    const events = this.deps.metricsCollector.getSecurityEvents();
+
+    // Count events by type
+    const eventCounts: Map<string, number> = new Map();
+    for (const eventType of Object.values(SecurityEventType)) {
+      eventCounts.set(eventType, 0);
+    }
+
+    for (const event of events) {
+      const current = eventCounts.get(event.type) || 0;
+      eventCounts.set(event.type, current + 1);
+    }
+
+    // Calculate deltas and increment counters
+    for (const [type, count] of eventCounts.entries()) {
+      const lastCount = this.lastSecurityEventCounts.get(type) || 0;
+      const delta = count - lastCount;
+      if (delta > 0) {
+        this.securityEventsTotal.labels(type).inc(delta);
+      }
+      this.lastSecurityEventCounts.set(type, count);
+    }
+  }
+
+  private updateToolMetrics(): void {
+    const registryMetrics = this.deps.registry.getMetrics();
+
+    // Update tools registered gauge
+    this.toolsRegistered.set(registryMetrics.totalTools);
+
+    // Update per-tool call counts
+    for (const toolName of registryMetrics.toolsRegistered) {
+      const toolStats = this.deps.registry.getToolStats(toolName);
+      if (toolStats) {
+        const lastCount = this.lastToolCallCounts.get(toolName) || 0;
+        const delta = toolStats.callCount - lastCount;
+        if (delta > 0) {
+          this.toolCallsTotal.labels(toolName).inc(delta);
+
+          // Record execution times in histogram
+          if (toolStats.averageExecutionTime > 0) {
+            // We can only record the average here; for accurate histograms,
+            // we'd need to instrument the actual tool execution
+            this.requestDuration.labels(toolName).observe(toolStats.averageExecutionTime / 1000);
+          }
+        }
+        this.lastToolCallCounts.set(toolName, toolStats.callCount);
+      }
+    }
+  }
+
+  private updateServicePoolMetrics(): void {
+    const stats = this.deps.serviceFactory.getStats();
+
+    this.servicePoolSize.set(stats.size);
+    this.servicePoolMaxSize.set(stats.maxSize);
+  }
+
+  private updateStorageMetrics(): void {
+    const stats = this.deps.lighthouseService.getStorageStats();
+
+    this.storageFiles.set(stats.fileCount);
+    this.storageBytes.set(stats.totalSize);
+    this.storageMaxBytes.set(stats.maxSize);
+    this.storageUtilization.set(stats.utilization);
+  }
+
+  /**
+   * Get metrics in Prometheus text format
+   */
+  async getMetrics(): Promise<string> {
+    // Update all metrics before export
+    this.updateMetrics();
+
+    // Return Prometheus text format
+    return this.registry.metrics();
+  }
+
+  /**
+   * Get content type for Prometheus response
+   */
+  getContentType(): string {
+    return this.registry.contentType;
+  }
+
+  /**
+   * Reset all custom metrics (useful for testing)
+   */
+  reset(): void {
+    this.registry.resetMetrics();
+    this.lastCacheCounters = { hits: 0, misses: 0 };
+    this.lastAuthMetrics = {
+      authenticatedRequests: 0,
+      failedAuthentications: 0,
+      fallbackRequests: 0,
+    };
+    this.lastSecurityEventCounts.clear();
+    this.lastToolCallCounts.clear();
+  }
+}

--- a/apps/mcp-server/src/health/index.ts
+++ b/apps/mcp-server/src/health/index.ts
@@ -1,3 +1,5 @@
 export { HealthCheckServer } from "./HealthCheckServer.js";
 export type { HealthCheckDependencies } from "./HealthCheckServer.js";
+export { PrometheusExporter } from "./PrometheusExporter.js";
+export type { PrometheusExporterDependencies } from "./PrometheusExporter.js";
 export * from "./types.js";

--- a/apps/mcp-server/src/health/types.ts
+++ b/apps/mcp-server/src/health/types.ts
@@ -8,6 +8,8 @@ export interface HealthCheckConfig {
   lighthouseApiUrl?: string;
   connectivityCheckInterval?: number;
   connectivityTimeout?: number;
+  /** Enable Prometheus metrics endpoint at /metrics */
+  metricsEnabled?: boolean;
 }
 
 export interface HealthStatus {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      prom-client:
+        specifier: ^15.1.0
+        version: 15.1.3
     devDependencies:
       "@types/better-sqlite3":
         specifier: ^7.6.12
@@ -1957,6 +1960,14 @@ packages:
       fastq: 1.19.1
     dev: false
 
+  /@opentelemetry/api@1.9.0:
+    resolution:
+      {
+        integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==,
+      }
+    engines: { node: ">=8.0.0" }
+    dev: false
+
   /@peculiar/asn1-schema@2.5.0:
     resolution:
       {
@@ -3292,6 +3303,13 @@ packages:
       }
     dependencies:
       file-uri-to-path: 1.0.0
+    dev: false
+
+  /bintrees@1.0.2:
+    resolution:
+      {
+        integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==,
+      }
     dev: false
 
   /bl@4.1.0:
@@ -7863,6 +7881,17 @@ packages:
     engines: { node: ">=0.4.0" }
     dev: false
 
+  /prom-client@15.1.3:
+    resolution:
+      {
+        integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==,
+      }
+    engines: { node: ^16 || ^18 || >=20 }
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      tdigest: 0.1.2
+    dev: false
+
   /prompts@2.4.2:
     resolution:
       {
@@ -8895,6 +8924,15 @@ packages:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  /tdigest@0.1.2:
+    resolution:
+      {
+        integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==,
+      }
+    dependencies:
+      bintrees: 1.0.2
+    dev: false
 
   /test-exclude@6.0.0:
     resolution:


### PR DESCRIPTION
# Pull Request

## Description

<!-- Please include a summary of the change and which issue is fixed. -->
https://github.com/Patrick-Ehimen/lighthouse-agent-tooling/issues/57.  Expose internal metrics in Prometheus format via /metrics endpoint for integration with standard monitoring stacks. Includes authentication, cache, tool usage, storage, and process metrics with histogram support for request latencies.
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- List any related issues, e.g. Fixes #123 -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Summary by Sourcery

Expose a Prometheus-compatible /metrics endpoint on the MCP server’s health check HTTP server to export internal metrics for external monitoring systems.

New Features:
- Add a Prometheus metrics exporter and /metrics HTTP endpoint on the health check server for scraping server metrics.
- Introduce authentication, cache, tool usage, security event, storage, service pool, and process metrics with histogram support for request and auth latencies.

Enhancements:
- Extend the authentication manager’s metrics collection to support Prometheus export, including cache hit/miss counters and security event aggregation.
- Add configurable health check metrics enablement via the PROMETHEUS_METRICS_ENABLED environment variable, enabled by default.

Build:
- Add the prom-client dependency to support Prometheus metrics collection and export.

Documentation:
- Document the Prometheus /metrics endpoint, available metrics, configuration options, and example Prometheus and Grafana setups in the MCP server README.